### PR TITLE
COM-4224: fix crash NSInternalInconsistencyException dans ActivityCardContainer et QuestionnaireCardContainer

### DIFF
--- a/src/screens/courses/ActivityCardContainer/index.tsx
+++ b/src/screens/courses/ActivityCardContainer/index.tsx
@@ -134,7 +134,7 @@ const ActivityCardContainer = ({ route, navigation }: ActivityCardContainerProps
 
   return isActive
     ? <SafeAreaView style={commonStyles.container} edges={[]}>
-      <Tab.Navigator tabBar={() => <></>} screenOptions={{ swipeEnabled: false }}>
+      <Tab.Navigator tabBar={() => <></>} screenOptions={{ swipeEnabled: false, animationEnabled: false }}>
         <Tab.Screen key={0} name={'startCard'} options={{ title: activity?.name || tabsNames.ActivityCardContainer }}>
           {() => <StartCard title={activity?.name || ''} goBack={goBack} isLoading={!(cards.length > 0 && activity)}
             startTimer={startTimer} />}

--- a/src/screens/courses/QuestionnaireCardContainer/index.tsx
+++ b/src/screens/courses/QuestionnaireCardContainer/index.tsx
@@ -104,7 +104,7 @@ const QuestionnaireCardContainer = ({ route, navigation }: QuestionnaireCardCont
 
   return isActive
     ? <SafeAreaView style={commonStyles.container} edges={[]}>
-      <Tab.Navigator tabBar={() => <></>} screenOptions={{ swipeEnabled: false }}>
+      <Tab.Navigator tabBar={() => <></>} screenOptions={{ swipeEnabled: false, animationEnabled: false }}>
         <Tab.Screen key={0} name={'startCard'} options={{ title: title || tabsNames.QuestionnaireCardContainer }}>
           {() => <StartCard title={title} goBack={goBack}
             isLoading={!cards.length || !questionnaires.length} />}


### PR DESCRIPTION
### TESTS  :computer:

- J'ai testé sur iphone : 
  - [ ] simulateur
  - [ ] physique
- J'ai testé sur android :
  - [ ] simulateur
  - [ ] physique
- [ ] J'ai testé sur navigateur

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [Doc de déploiement](https://www.notion.so/compani/Distribution-mobile-MEP-d7238605d8c74cc59fa724ca5d94f253) ce qu'il fallait mettre à jour
- [ ] ~~Mes changements entrainent une incompatibilité avec l'ancienne version de l'api~~
  - [ ] Si oui, j'ai noté dans le [Doc de déploiement](https://www.notion.so/compani/Distribution-mobile-MEP-d7238605d8c74cc59fa724ca5d94f253) qu'il faut fusionner l'api dans staging avant d'envoyer le build et déprécier les anciennes versions

_Si tu as lu cette description, pense à réagir avec un :eye:_

---

## 🧪 Rapport de test — 20/08/2026

Cette PR était ouverte depuis le **19/05** sans description ni case cochée ; ce rapport la complète.
Reprise dans le cadre de la revue des PR en attente, avec un angle précis : **elle touche exactement les deux composants concernés
par la montée de `@react-navigation` (#808)**, il fallait donc vérifier qu'elles ne se marchent pas dessus.

### Le correctif

Deux lignes, une par composant : `animationEnabled: false` ajouté aux `screenOptions` du `Tab.Navigator`
de `material-top-tabs`, dans `ActivityCardContainer` et `QuestionnaireCardContainer`.

Les deux navigateurs sont déjà montés avec `tabBar={() => <></>}` et `swipeEnabled: false` : la barre
d'onglets est masquée et le glissement désactivé — le composant sert de **machine à états entre cartes**,
pas d'onglets navigables. Désactiver l'animation de transition est donc cohérent avec cet usage : il n'y a
aucun geste utilisateur dont l'animation serait le retour visuel.

### Compatibilité avec la montée de `@react-navigation` (#808) — le point que je voulais lever

`animationEnabled` est une option de `material-top-tabs`, et #808 monte ce paquet de **7.4.23 à 7.6.16**.
Le risque était que l'option disparaisse ou change de sémantique, rendant ce correctif inopérant.

Vérifié dans les types de la version cible :

```
node_modules/@react-navigation/material-top-tabs/lib/typescript/src/types.d.ts:165
    animationEnabled?: boolean;
```

**L'option existe toujours en 7.6.16.** Et j'ai testé la combinaison réelle en appliquant ce correctif
par-dessus la branche de #808 :

| Contrôle | Résultat |
|---|---|
| Cherry-pick de `COM-4224` sur `COM-4278` | ✅ **aucun conflit** |
| `tsc --noEmit` + `eslint` sur les deux cumulés | ✅ propres |
| `yarn test` | ✅ 1 suite, 1 test |

**Les deux PR sont donc compatibles**, dans les deux sens de merge. C'était l'inquiétude principale, elle
est levée.

### Non couvert — et c'est important ici

- **Le crash lui-même n'a pas été reproduit ni sa correction constatée.** `ActivityCardContainer` et
  `QuestionnaireCardContainer` sont **derrière la connexion** (parcours d'un cours), et `BASE_URL_LOCAL`
  pointe sur `api.dev.compani.fr`, un environnement partagé sur lequel je ne me suis pas authentifié. Je n'ai
  donc **pas vu ces deux écrans tourner**, ni avant ni après le correctif.
- **Le lien de causalité entre `animationEnabled` et `NSInternalInconsistencyException` n'est pas établi
  ici.** L'hypothèse est plausible (l'animation de `react-native-pager-view` manipule la hiérarchie de vues
  native pendant une transition, ce qui est un candidat classique pour cette exception), mais ce rapport ne
  la démontre pas. Si un lien Sentry ou une trace de l'époque existe, l'ajouter à la description rendrait la
  review beaucoup plus solide.
- **État Sentry actuel** : `NSInternalInconsistencyException` n'apparaît pas dans les issues non résolues du
  projet mobile aujourd'hui. Je n'en tire aucune conclusion — je n'ai pas pu interroger les issues résolues
  ou ignorées, donc je ne sais pas si le crash a été corrigé autrement, s'il est devenu rare, ou s'il est
  simplement passé sous le radar.
- **Android** : non testé. `material-top-tabs` repose sur `react-native-pager-view`, dont l'implémentation
  native diffère entre les deux plateformes — or l'exception rapportée est **iOS** (`NS...Exception`).

### Ce qu'il faudrait pour valider vraiment

Un parcours réel : ouvrir une activité et un questionnaire depuis un cours, enchaîner les cartes dans les
deux sens, et vérifier l'absence de crash — idéalement sur un appareil physique, ces exceptions de hiérarchie
de vues étant sensibles au timing. Avec un compte de test sur l'environnement dev, c'est faisable en une
dizaine de minutes.

**En l'état, ce que ce rapport établit** : le correctif est syntaxiquement valide, cohérent avec l'usage des
composants, et **compatible avec la montée #808**. Ce qu'il n'établit pas : qu'il corrige effectivement le
crash.


---

## 🩺 Note `react-doctor` — 20/08/2026

Passe d'analyse statique avec [`react-doctor@0.9.12`](https://github.com/millionco/react-doctor) sur toutes
les branches de `compani-formation`. Deux constats pour cette PR :

**Le score de cette branche est plus bas, mais ce n'est pas la PR.** `COM-4224` obtient 47 / 3 erreurs / 274
warnings, contre **50 / 2 / 214 sur `dev`**. L'écart vient de son âge : la branche part d'un `dev` du
**19/05** et accuse **63 commits de retard**, pour un diff de 2 lignes. Le score reflète l'état du code de
mai, pas ce correctif. Un rebase sur `dev` l'alignerait — et vaudrait le coup avant merge, la branche ayant
3 mois.

**`ActivityCardContainer` concentre 5 diagnostics**, dont une « erreur » `effect-needs-cleanup` (l.88) qui
est un **faux positif** : le `useEffect` retourne bien `() => { remove(); }`, mais l'outil ne reconnaît pas le
motif `const { remove } = AppState.addEventListener(...)` de React Native et cherche un
`removeEventListener`. Le diagnostic porte d'ailleurs le tag `test-noise`. Rien à corriger.

Les autres diagnostics sur ce fichier sont des warnings préexistants sur `dev`, sans rapport avec
`animationEnabled`.


