### PR TITLE
COM-4251: Aligner ios.buildNumber sur versionCode pour unifier les releases Sentry

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -19,6 +19,9 @@ const ENVIRONMENT_VARIABLES = {
   PLATFORM: process.env.PLATFORM,
 };
 
+const APP_VERSION = '2.43.0';
+const VERSION_CODE = 370;
+
 const LOCAL = 'local';
 const DEVELOPMENT = 'development';
 const PRODUCTION = 'production';
@@ -44,7 +47,7 @@ export default {
     slug: 'compani',
     description: 'Nous aidons les intervenants, les managers du secteur et les dirigeants à pratiquer un accompagnement humain',
     platforms: ['ios', 'android', 'web'],
-    version: '2.43.0',
+    version: APP_VERSION,
     orientation: 'portrait',
     primaryColor: '#005774',
     icon: './assets/images/ios_icon.png',
@@ -70,7 +73,7 @@ export default {
       color: '#005774',
     },
     ios: {
-      buildNumber: '2.43.0',
+      buildNumber: String(VERSION_CODE),
       bundleIdentifier: variables.bundleIdentifier,
       requireFullScreen: true,
       icon: './assets/images/ios_icon.png',
@@ -112,7 +115,7 @@ export default {
         resizeMode: 'cover',
         backgroundColor: '#FFFFFF',
       },
-      versionCode: 370,
+      versionCode: VERSION_CODE,
     },
     web: {
       favicon: './assets/images/android_icon_old.png',

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -5,13 +5,18 @@ import * as Notifications from 'expo-notifications';
 import { Provider as ReduxProvider } from 'react-redux';
 import * as SplashScreen from 'expo-splash-screen';
 import * as Sentry from '@sentry/react-native';
+import Constants from 'expo-constants';
 import { Provider as AuthProvider } from '../context/AuthContext';
 import AppContainer from '../AppContainer';
 import store from '../store/store';
 import Environment from '../../environment';
 import { initializeAssets } from '../core/helpers/assets';
 
-Sentry.init({ dsn: Environment.getSentryKey(), debug: false });
+Sentry.init({
+  dsn: Environment.getSentryKey(),
+  debug: false,
+  environment: Constants.expoConfig?.extra?.PROFILE || 'production',
+});
 
 try {
   Notifications.setNotificationHandler({

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -11,11 +11,12 @@ import AppContainer from '../AppContainer';
 import store from '../store/store';
 import Environment from '../../environment';
 import { initializeAssets } from '../core/helpers/assets';
+import { PRODUCTION } from '../core/data/constants';
 
 Sentry.init({
   dsn: Environment.getSentryKey(),
   debug: false,
-  environment: Constants.expoConfig?.extra?.PROFILE || 'production',
+  environment: Constants.expoConfig?.extra?.PROFILE || PRODUCTION,
 });
 
 try {


### PR DESCRIPTION
### TESTS  :computer:

- J'ai testé sur iphone : 
  - [ ] simulateur
  - [ ] physique
- J'ai testé sur android :
  - [ ] simulateur
  - [ ] physique
- [ ] J'ai testé sur navigateur

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] ~~J'ai ajouté une variable d'environnement~~
  - [ ] Si oui, J'ai précisé sur le [Doc de déploiement](https://www.notion.so/compani/Distribution-mobile-MEP-d7238605d8c74cc59fa724ca5d94f253) ce qu'il fallait mettre à jour
- [ ] ~~Mes changements entrainent une incompatibilité avec l'ancienne version de l'api~~
  - [ ] Si oui, j'ai noté dans le [Doc de déploiement](https://www.notion.so/compani/Distribution-mobile-MEP-d7238605d8c74cc59fa724ca5d94f253) qu'il faut fusionner l'api dans staging avant d'envoyer le build et déprécier les anciennes versions

---

## Description

Correction du versioning Sentry pour eviter la fragmentation des releases entre iOS et Android.

`ios.buildNumber` etait a `'2.43.0'` (version string) tandis que `android.versionCode` etait `370` (entier incremental). Sentry creait deux releases distinctes pour la meme version :
- iOS → `com.alenvi.compani@2.43.0+2.43.0`
- Android → `com.alenvi.compani@2.43.0+370`

### Changements

1. **app.config.js** : extraction de `APP_VERSION` et `VERSION_CODE` en constantes, `ios.buildNumber` utilise `String(VERSION_CODE)` au lieu de la version
2. **src/App/index.tsx** : ajout de `environment` dans `Sentry.init()` pour distinguer les profils de build (production/development/local)

### Ticket

COM-4251

_Si tu as lu cette description, pense à réagir avec un :eye:_