### PR TITLE
COM-4275: assainir les dépendances Expo avant le passage au SDK 56

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@eslint/js": "~10.0.1",
-    "@expo/metro-runtime": "~55.0.11",
+    "@expo/metro-runtime": "~55.0.12",
     "@formatjs/intl-datetimeformat": "~7.3.1",
     "@formatjs/intl-getcanonicallocales": "~3.2.2",
     "@formatjs/intl-locale": "~5.3.1",
@@ -57,28 +57,28 @@
     "eslint-config-airbnb-base": "~15.0.0",
     "eslint-plugin-import": "~2.32.0",
     "eslint-plugin-jest": "~29.15.1",
-    "expo": "~55.0.26",
-    "expo-application": "~55.0.15",
-    "expo-asset": "~55.0.17",
-    "expo-audio": "~55.0.14",
-    "expo-build-properties": "~55.0.14",
-    "expo-constants": "~55.0.16",
-    "expo-dev-client": "~55.0.35",
-    "expo-device": "~55.0.17",
-    "expo-file-system": "~55.0.22",
+    "expo": "~55.0.28",
+    "expo-application": "~55.0.17",
+    "expo-asset": "~55.0.18",
+    "expo-audio": "~55.0.16",
+    "expo-build-properties": "~55.0.16",
+    "expo-constants": "~55.0.17",
+    "expo-dev-client": "~55.0.37",
+    "expo-device": "~55.0.19",
+    "expo-file-system": "~55.0.24",
     "expo-font": "~55.0.8",
-    "expo-image-manipulator": "~55.0.17",
-    "expo-image-picker": "~55.0.20",
-    "expo-intent-launcher": "~55.0.12",
-    "expo-linear-gradient": "~55.0.14",
-    "expo-notifications": "~55.0.23",
-    "expo-print": "~55.0.15",
-    "expo-screen-orientation": "~55.0.16",
-    "expo-sharing": "~55.0.20",
-    "expo-splash-screen": "~55.0.21",
-    "expo-system-ui": "~55.0.18",
-    "expo-updates": "~55.0.24",
-    "expo-video": "~55.0.17",
+    "expo-image-manipulator": "~55.0.19",
+    "expo-image-picker": "~55.0.22",
+    "expo-intent-launcher": "~55.0.14",
+    "expo-linear-gradient": "~55.0.16",
+    "expo-notifications": "~55.0.25",
+    "expo-print": "~55.0.17",
+    "expo-screen-orientation": "~55.0.18",
+    "expo-sharing": "~55.0.22",
+    "expo-splash-screen": "~55.0.23",
+    "expo-system-ui": "~55.0.20",
+    "expo-updates": "~55.0.26",
+    "expo-video": "~55.0.19",
     "globals": "~17.4.0",
     "luxon": "~3.7.2",
     "metro": "~0.83.3",
@@ -88,7 +88,7 @@
     "qs": "~6.15.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-native": "0.83.6",
+    "react-native": "0.83.10",
     "react-native-drax": "~1.1.0",
     "react-native-gesture-handler": "~2.30.0",
     "react-native-markdown-display": "~7.0.2",
@@ -124,7 +124,7 @@
     "eslint-plugin-react-hooks": "~7.0.1",
     "expo-doctor": "~1.18.14",
     "jest": "~29.7.0",
-    "jest-expo": "~55.0.18",
+    "jest-expo": "~55.0.20",
     "sinon": "~21.0.3",
     "ts-jest": "~29.4.9",
     "typescript": "~5.9.2"
@@ -132,5 +132,12 @@
   "engines": {
     "node": "~22.20.0"
   },
-  "private": true
+  "private": true,
+  "expo": {
+    "install": {
+      "exclude": [
+        "@sentry/react-native"
+      ]
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -962,32 +962,32 @@
     "@eslint/core" "^1.2.0"
     levn "^0.4.1"
 
-"@expo/cli@55.0.32":
-  version "55.0.32"
-  resolved "https://registry.yarnpkg.com/@expo/cli/-/cli-55.0.32.tgz#143a472f7abd0f827d31ad6a0b7fc04b782e5066"
-  integrity sha512-fq+/yUYBVw5ZudT4igNyJ3WaF17R39iS7EZlrkfHkLI7Y1kmUlivabwKviLoAfepJOKjKODKpViti9EPfmG3SQ==
+"@expo/cli@55.0.34":
+  version "55.0.34"
+  resolved "https://registry.yarnpkg.com/@expo/cli/-/cli-55.0.34.tgz#da5d5e4d895b5d710fb0d9b38efba896cabc35ff"
+  integrity sha512-b+PnIWiIUxXmSi09hmbzeBNlygP/W1uuRQU6cm6ke9P5sBEknbZ4cpBY0Xz4L1L3Pr6u/BUbIW0KXJBOppzAww==
   dependencies:
     "@expo/code-signing-certificates" "^0.0.6"
-    "@expo/config" "~55.0.17"
-    "@expo/config-plugins" "~55.0.10"
+    "@expo/config" "~55.0.19"
+    "@expo/config-plugins" "~55.0.11"
     "@expo/devcert" "^1.2.1"
-    "@expo/env" "~2.1.2"
-    "@expo/image-utils" "^0.8.14"
+    "@expo/env" "~2.1.3"
+    "@expo/image-utils" "^0.8.15"
     "@expo/json-file" "^10.0.15"
-    "@expo/log-box" "55.0.12"
+    "@expo/log-box" "55.0.13"
     "@expo/metro" "~55.1.1"
-    "@expo/metro-config" "~55.0.23"
+    "@expo/metro-config" "~55.0.25"
     "@expo/osascript" "^2.4.4"
-    "@expo/package-manager" "^1.10.5"
+    "@expo/package-manager" "^1.10.6"
     "@expo/plist" "^0.5.4"
-    "@expo/prebuild-config" "^55.0.18"
-    "@expo/require-utils" "^55.0.5"
+    "@expo/prebuild-config" "^55.0.20"
+    "@expo/require-utils" "^55.0.6"
     "@expo/router-server" "^55.0.18"
-    "@expo/schema-utils" "^55.0.4"
+    "@expo/schema-utils" "^55.0.5"
     "@expo/spawn-async" "^1.7.2"
     "@expo/ws-tunnel" "^1.0.1"
     "@expo/xcpretty" "^4.4.0"
-    "@react-native/dev-middleware" "0.83.6"
+    "@react-native/dev-middleware" "0.83.10"
     accepts "^1.3.8"
     arg "^5.0.2"
     better-opn "~3.0.2"
@@ -998,7 +998,7 @@
     compression "^1.7.4"
     connect "^3.7.0"
     debug "^4.3.4"
-    dnssd-advertise "^1.1.4"
+    dnssd-advertise "^1.1.6"
     expo-server "^55.0.11"
     fetch-nodeshim "^0.4.10"
     getenv "^2.0.0"
@@ -1032,12 +1032,12 @@
   dependencies:
     node-forge "^1.3.3"
 
-"@expo/config-plugins@^55.0.10", "@expo/config-plugins@~55.0.10", "@expo/config-plugins@~55.0.9":
-  version "55.0.10"
-  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-55.0.10.tgz#d54e95f2d8cf805d0c23885d5b525afb03b41437"
-  integrity sha512-1txnRnMLIO5lM/Of/VyvDkCwZap0YFvCyfSTIlUQamhwhx6Rh7r8TXfcIstaDYUQ7X6GTMkNxLXWbcYS6ZAFDw==
+"@expo/config-plugins@^55.0.11", "@expo/config-plugins@~55.0.11":
+  version "55.0.11"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-55.0.11.tgz#762c129a645b429394a47873bc68a5e512deac99"
+  integrity sha512-85ZSmIK8rMfvYbG/2IHtwnykVdb6LI0ZavduM3ZwUMThyyVegYjVsO5Zek2ec8xzPhCmYX0ar5onnFEcwUDUlw==
   dependencies:
-    "@expo/config-types" "^55.0.5"
+    "@expo/config-types" "^55.0.6"
     "@expo/json-file" "~10.0.15"
     "@expo/plist" "^0.5.4"
     "@expo/sdk-runtime-versions" "^1.0.0"
@@ -1051,20 +1051,20 @@
     xcode "^3.0.1"
     xml2js "0.6.0"
 
-"@expo/config-types@^55.0.5":
-  version "55.0.5"
-  resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-55.0.5.tgz#731ce3e95866254e18977c0026ebab8a00dd6e10"
-  integrity sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==
+"@expo/config-types@^55.0.6":
+  version "55.0.6"
+  resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-55.0.6.tgz#82e33201542f00a2956a13a45f9824e2388a60a0"
+  integrity sha512-S+GJKYoIjnWlert/9vXuTohaTsMbyOLSVxdIgPgoq3P4N1p4CWrfyZLnz6qRug8wYSO5fcYcS9mFleyEP8wRLg==
 
-"@expo/config@~55.0.17":
-  version "55.0.17"
-  resolved "https://registry.yarnpkg.com/@expo/config/-/config-55.0.17.tgz#6c8592880c3ccaee78277ea3ddfa163b8c6ad6f4"
-  integrity sha512-Y3VaRg7Jllg3MhlUOTQqHm6/dttsqcjYlnS9enhAllZvPUpTHnRA4YPETtUZlxkdMJy6y3UZe986pd/KfJ6OTg==
+"@expo/config@~55.0.19":
+  version "55.0.19"
+  resolved "https://registry.yarnpkg.com/@expo/config/-/config-55.0.19.tgz#4579075449147c23e014a875f0818e48bba03e77"
+  integrity sha512-MahrCR6LsElK/1r/C/zfEZ5Pdgmo88Gtd4CCnASv/rC2pUIB+ENt2oKRHAPIWi7McTeoqDPb9KwCkQBpNMOjrg==
   dependencies:
-    "@expo/config-plugins" "~55.0.9"
-    "@expo/config-types" "^55.0.5"
-    "@expo/json-file" "^10.0.14"
-    "@expo/require-utils" "^55.0.5"
+    "@expo/config-plugins" "~55.0.11"
+    "@expo/config-types" "^55.0.6"
+    "@expo/json-file" "^10.0.15"
+    "@expo/require-utils" "^55.0.6"
     deepmerge "^4.3.1"
     getenv "^2.0.0"
     glob "^13.0.0"
@@ -1092,30 +1092,30 @@
   resolved "https://registry.yarnpkg.com/@expo/dom-webview/-/dom-webview-55.0.6.tgz#216908464ddf0196a2828210042712a651109f20"
   integrity sha512-ZNm8tiNEZysxrr36J0x4mOCGyJDcaIvL/3tMxBz0VJIJDcV19xjuJAhJQxHovu+jKx6s9tRyEAINa1mdrzV39g==
 
-"@expo/env@^2.1.2":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@expo/env/-/env-2.3.0.tgz#dbdecd1b64b07840f9d5922a48a06c66bea5fe7c"
-  integrity sha512-9HnnIbzwTTdbwSjNLXTk0fPm9ZwMJ7c1/31tsni8HZ8Q62KzYCyspahH+V365vg5J6lr001DzNwBxVWSaYCQLg==
+"@expo/env@^2.1.3":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@expo/env/-/env-2.4.2.tgz#c180fd577e664b6090029157ae0e1b7ddfd66fac"
+  integrity sha512-28pqaEqwnmLduZ00Pq9HkSzE5wbj1MTwp5/n8nm8rD8MCjR9eUnVOwmNksPI3Be2ReAPO/DbPn1puy0mvoocsQ==
   dependencies:
     chalk "^4.0.0"
     debug "^4.3.4"
     getenv "^2.0.0"
 
-"@expo/env@~2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@expo/env/-/env-2.1.2.tgz#c25ecadc60555873761a02c4b85bdd1663fa568c"
-  integrity sha512-RJtGFfj/ygO/6zcVbV3cckHf4THcEkv5IZft1GjCB3dfT6axvzvIwXE9EiQqQYmGHcQ+ZrvC8xZcIhiHba0pYg==
+"@expo/env@~2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@expo/env/-/env-2.1.3.tgz#69bc9a63b0d99e1656f853b34b779656c79d0d47"
+  integrity sha512-Rhu/lJ1kOhqzJvLwW0iB4WKUzB1nFa8WBwXFL44qkSTNwibjrbI8lA46Ix6W2MMTdlUqL1m85Gdyx0T7nGpREg==
   dependencies:
     chalk "^4.0.0"
     debug "^4.3.4"
     getenv "^2.0.0"
 
-"@expo/fingerprint@0.16.7":
-  version "0.16.7"
-  resolved "https://registry.yarnpkg.com/@expo/fingerprint/-/fingerprint-0.16.7.tgz#288719e85e4da2f624ad9b42128f4e86384dd198"
-  integrity sha512-BH8sicYOqZ1iBMwCVEGIz6uTTfylosjc49FoMmCYIzKOiYdiVehsfoYBwyfxwWIiya1VMhm1gv0cgOP8fxHpDw==
+"@expo/fingerprint@0.16.8":
+  version "0.16.8"
+  resolved "https://registry.yarnpkg.com/@expo/fingerprint/-/fingerprint-0.16.8.tgz#8063a6f6f1742e3aefc0f044c5bae9a60b3342bf"
+  integrity sha512-RaLOikl+alkvG9ZrBQFGi3kVXJdG5GQXY1H3V1ZFCwFyhFikwuBozVrl4KL7U+N0Tm8Bf1qDmpTEIx8JOyrQog==
   dependencies:
-    "@expo/env" "^2.1.2"
+    "@expo/env" "^2.1.3"
     "@expo/spawn-async" "^1.7.2"
     arg "^5.0.2"
     chalk "^4.1.2"
@@ -1127,12 +1127,12 @@
     resolve-from "^5.0.0"
     semver "^7.6.0"
 
-"@expo/image-utils@^0.8.14":
-  version "0.8.14"
-  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.8.14.tgz#1c4bf2e6787436ae14beb834b7c36133329de842"
-  integrity sha512-5Sn+jG4Cw+shC2wDMXoqSAJnvERbiwzHn05FpWtD5IBflfTIs5gUmjzwiGVyjOdlMSQhgRrw/AymPbmO9h9mpQ==
+"@expo/image-utils@^0.8.15":
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.8.15.tgz#65a7985c7aa6d2a2a76ac691772af923997d6872"
+  integrity sha512-3f5CgKJnJ8m4mp8VTcAFQqLrxof99RDr77Aa+7hgzDPg3ZotjLnofl77hf+COQRYi/kuqRYdYFgPIqOIOIdWJA==
   dependencies:
-    "@expo/require-utils" "^55.0.5"
+    "@expo/require-utils" "^55.0.6"
     "@expo/spawn-async" "^1.7.2"
     chalk "^4.0.0"
     getenv "^2.0.0"
@@ -1140,10 +1140,18 @@
     parse-png "^2.1.0"
     semver "^7.6.0"
 
-"@expo/json-file@^10.0.14", "@expo/json-file@^10.0.15", "@expo/json-file@^10.2.0":
+"@expo/json-file@^10.0.15":
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-10.2.0.tgz#a63fca4445f2457a60407a3d76da8bfd0221e9a4"
   integrity sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==
+  dependencies:
+    "@babel/code-frame" "^7.20.0"
+    json5 "^2.2.3"
+
+"@expo/json-file@^11.0.1":
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-11.0.1.tgz#dab8f6e5ff78e7c33a8e49a48722ce972306036c"
+  integrity sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ==
   dependencies:
     "@babel/code-frame" "^7.20.0"
     json5 "^2.2.3"
@@ -1156,33 +1164,33 @@
     "@babel/code-frame" "~7.10.4"
     json5 "^2.2.3"
 
-"@expo/local-build-cache-provider@55.0.13":
-  version "55.0.13"
-  resolved "https://registry.yarnpkg.com/@expo/local-build-cache-provider/-/local-build-cache-provider-55.0.13.tgz#05244ac0df9e06e3986238c8002d534b00fb5c3e"
-  integrity sha512-Vg5BE10UL+0yg3BVtIeiSoeHU31Qe1m3UxhBPS478ACY1zzKuxZE30x2sym/B2OIWypjmPzXDRt8J9TOGFuFNw==
+"@expo/local-build-cache-provider@55.0.15":
+  version "55.0.15"
+  resolved "https://registry.yarnpkg.com/@expo/local-build-cache-provider/-/local-build-cache-provider-55.0.15.tgz#4ed892f39762975451ee8f27c70658d1d301f54d"
+  integrity sha512-coFNPt2gGmWtTJwqHlvx/Us9/VWK+pTHuP4jv/NM5jaHZuN0FhX7m2FvwthbluHUGpaVBc8+AxEDmDVqTfKtHg==
   dependencies:
-    "@expo/config" "~55.0.17"
+    "@expo/config" "~55.0.19"
     chalk "^4.1.2"
 
-"@expo/log-box@55.0.12":
-  version "55.0.12"
-  resolved "https://registry.yarnpkg.com/@expo/log-box/-/log-box-55.0.12.tgz#da3bb055eb094916f88d5fee8b918d7a0a628467"
-  integrity sha512-f9ARS8J60cq3LLNdIqmUjYwyerBzVS5Ecp7KjIf3GOIPjW0571rkcwLz4/U18l/1DeSkSzIkYsNl2TC9oTdWaQ==
+"@expo/log-box@55.0.13":
+  version "55.0.13"
+  resolved "https://registry.yarnpkg.com/@expo/log-box/-/log-box-55.0.13.tgz#3c815e3129f7f426751e1334658963a7738d7f02"
+  integrity sha512-pV623uwyKjw/L1HVWOpwWOu/ISLH1+c+ESVv30alQMbEaE3cLcwcQ+UnHiAGayMBNMQwK57eckOgH40RBXHfCA==
   dependencies:
     "@expo/dom-webview" "^55.0.6"
     anser "^1.4.9"
     stacktrace-parser "^0.1.10"
 
-"@expo/metro-config@55.0.23", "@expo/metro-config@~55.0.23":
-  version "55.0.23"
-  resolved "https://registry.yarnpkg.com/@expo/metro-config/-/metro-config-55.0.23.tgz#1548b42b7428d714620b84581112c002e5838677"
-  integrity sha512-Mkw3Ss/1LFlafH3iie3r9E13yKMyJgZqGTEkGviGf6LYp51eY5fR8ATbXrNsH69wVc2z+ty4lT/8lEA18YJv7g==
+"@expo/metro-config@55.0.25", "@expo/metro-config@~55.0.25":
+  version "55.0.25"
+  resolved "https://registry.yarnpkg.com/@expo/metro-config/-/metro-config-55.0.25.tgz#336ac482d68209694d68846de02f08b9b3fd4972"
+  integrity sha512-3KXVaIdawin16YXXDK4P3HGYjnlNqq/34dqb0kvoTM9RBDWbuq+zYkanLRHKLrDkDLODv7vSvbQNAATt76my0Q==
   dependencies:
     "@babel/code-frame" "^7.20.0"
     "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.5"
-    "@expo/config" "~55.0.17"
-    "@expo/env" "~2.1.2"
+    "@expo/config" "~55.0.19"
+    "@expo/env" "~2.1.3"
     "@expo/json-file" "~10.0.15"
     "@expo/metro" "~55.1.1"
     "@expo/spawn-async" "^1.7.2"
@@ -1198,12 +1206,12 @@
     postcss "^8.5.14"
     resolve-from "^5.0.0"
 
-"@expo/metro-runtime@~55.0.11":
-  version "55.0.11"
-  resolved "https://registry.yarnpkg.com/@expo/metro-runtime/-/metro-runtime-55.0.11.tgz#86abebda2ba21c697f9672202b8f3de54b618d18"
-  integrity sha512-4KKi/jGrIEXi2YGu0hYTVr0CEeRJy5SXbCrz9+KDZkuD3ROwKNpM1DBawni5rhPVovFnR323HBck9GaxhnfrRw==
+"@expo/metro-runtime@~55.0.12":
+  version "55.0.12"
+  resolved "https://registry.yarnpkg.com/@expo/metro-runtime/-/metro-runtime-55.0.12.tgz#0bef002e19249f46feeadbc5e6f4d6a7c8763b0f"
+  integrity sha512-EeqXrRBvChdt6+brlUkZM5749QoS7OlN7Zsn/AT8hhGV+xNKglirVRkcKQFmKqPgjgmNxfwgLJ6ddanwZ9dapg==
   dependencies:
-    "@expo/log-box" "55.0.12"
+    "@expo/log-box" "55.0.13"
     anser "^1.4.9"
     pretty-format "^29.7.0"
     stacktrace-parser "^0.1.10"
@@ -1236,12 +1244,12 @@
   dependencies:
     "@expo/spawn-async" "^1.8.0"
 
-"@expo/package-manager@^1.10.5":
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/@expo/package-manager/-/package-manager-1.12.1.tgz#25f6241ba7844887b74668d7c4b44336b1b381f6"
-  integrity sha512-fQLiFAcFRWF53mtuLK32SUJQ1ahhrTcBZPZPedYTiUT5ha5FF+UO6bPtCc0Y/hgj0/m3HCGBAuSHjbg2kI9oPQ==
+"@expo/package-manager@^1.10.6":
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/@expo/package-manager/-/package-manager-1.13.1.tgz#a6ce56c602a70e33ed376525dd100945e19006f9"
+  integrity sha512-y/K+CaYYpZpNGZhSX4HyLT/vyIunFjNfyoxNysPBCefeLKI/VCx6f9LNPzrxayr3rCYO5bl9O8H+HRQK265Nkg==
   dependencies:
-    "@expo/json-file" "^10.2.0"
+    "@expo/json-file" "^11.0.1"
     "@expo/spawn-async" "^1.8.0"
     chalk "^4.0.0"
     npm-package-arg "^11.0.0"
@@ -1257,26 +1265,26 @@
     base64-js "^1.5.1"
     xmlbuilder "^15.1.1"
 
-"@expo/prebuild-config@^55.0.18":
-  version "55.0.18"
-  resolved "https://registry.yarnpkg.com/@expo/prebuild-config/-/prebuild-config-55.0.18.tgz#8c9e08a2555f1f241292380ddf38c3346a2ebdb0"
-  integrity sha512-2oKXyy5pyM87DJqXW5Z+Sakle6rApFFtpPhWOiNsOdoh6rOAD+EqVgyrs2OEEic8CE0tTt27w3SRfSZe/PZrxg==
+"@expo/prebuild-config@^55.0.20":
+  version "55.0.20"
+  resolved "https://registry.yarnpkg.com/@expo/prebuild-config/-/prebuild-config-55.0.20.tgz#bd23fadc65bfb0dcbaa3348de949799c4dc23f27"
+  integrity sha512-Cy9xnwK0f3aG0TbKkBFuVQCtd6rj22muYfj7o1iCAE0NOUy5ks1k2vcmlKD1g48wzcWw0hFySiwtaGsB9qeVRQ==
   dependencies:
-    "@expo/config" "~55.0.17"
-    "@expo/config-plugins" "~55.0.9"
-    "@expo/config-types" "^55.0.5"
-    "@expo/image-utils" "^0.8.14"
-    "@expo/json-file" "^10.0.14"
-    "@react-native/normalize-colors" "0.83.6"
+    "@expo/config" "~55.0.19"
+    "@expo/config-plugins" "~55.0.11"
+    "@expo/config-types" "^55.0.6"
+    "@expo/image-utils" "^0.8.15"
+    "@expo/json-file" "^10.0.15"
+    "@react-native/normalize-colors" "0.83.10"
     debug "^4.3.1"
     resolve-from "^5.0.0"
     semver "^7.6.0"
     xml2js "0.6.0"
 
-"@expo/require-utils@^55.0.5":
-  version "55.0.5"
-  resolved "https://registry.yarnpkg.com/@expo/require-utils/-/require-utils-55.0.5.tgz#50ac2bd7fa74d8c55749c88c2bef19d4d23e0b84"
-  integrity sha512-U4K/CQ2VpXuwfNGsN+daKmYOt15hCP8v/pXaYH6eut7kdYZo6SfJ1yr67BIcJ+1Gzzs+QzTxswAZChKpXmceyw==
+"@expo/require-utils@^55.0.6":
+  version "55.0.6"
+  resolved "https://registry.yarnpkg.com/@expo/require-utils/-/require-utils-55.0.6.tgz#37e21d7616809ee00eae24b52c6bb09ffbcc660d"
+  integrity sha512-IqsRGPdGbF0lAIrg3XQ+GzcITYcsskvIRmFAjw2kBnr8RgSrRhFAJY1bKksukEUsuZy0knhTCVIIUce7hocqeA==
   dependencies:
     "@babel/code-frame" "^7.20.0"
     "@babel/core" "^7.25.2"
@@ -1289,10 +1297,10 @@
   dependencies:
     debug "^4.3.4"
 
-"@expo/schema-utils@^55.0.4":
-  version "55.0.4"
-  resolved "https://registry.yarnpkg.com/@expo/schema-utils/-/schema-utils-55.0.4.tgz#2039daa04933da8f27957fd61b2b6d8d22d34bba"
-  integrity sha512-65IdeeE8dAZR3n3J5Eq7LYiQ8BFGeEYCWPBCzycvafL7PkskbCyIclTQarRwf/HXFoRvezKCjaLwy/8v9Prk6g==
+"@expo/schema-utils@^55.0.5":
+  version "55.0.5"
+  resolved "https://registry.yarnpkg.com/@expo/schema-utils/-/schema-utils-55.0.5.tgz#42669be01398060db6ed25337342646411aa8498"
+  integrity sha512-wdV4SzWJ/l+6y/r9vDaqPqXGyfxUD1igbX8rRbRBfkVXenAUY2qenq6HF4S0iJ0pjpVDNTANn5aQY7VV55hhsA==
 
 "@expo/sdk-runtime-versions@^1.0.0":
   version "1.0.0"
@@ -1784,10 +1792,18 @@
   resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.3.2.tgz#7064533a573e3539ec912f59c1f457371bf49dd9"
   integrity sha512-XwuQoW7/GEgWRMovOQtX3A4PrXhyaZm0lVUiY8qJDvdngjLms9Cpdck6SmGAUNqQwcj2EadHC1HwL0bEyoa/SQ==
 
-"@react-native/assets-registry@0.83.6":
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.83.6.tgz#36c4d986aa2903ab05c29589749618cfd9d2a258"
-  integrity sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg==
+"@react-native/assets-registry@0.83.10":
+  version "0.83.10"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.83.10.tgz#901a076818c72e3d7946af735709eeaaddd35fb6"
+  integrity sha512-AcVfyQ+8HsWCecXEnSaRffP71KqaWrhNB8bLulYCpKO7i5h/lmwgF191uafU/WiS0LbEMTGlXwWBshPto1phyA==
+
+"@react-native/babel-plugin-codegen@0.83.10":
+  version "0.83.10"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.83.10.tgz#f1863214401e135f19537d947ba500128d47daf9"
+  integrity sha512-iRfhxsOePloy12TUzpL9dCwnxLi3eurg8+JurSozAmWh4HtmKu0IJHNjbEKk9htI5n4RlFom8LQ9vVcvgWOTbw==
+  dependencies:
+    "@babel/traverse" "^7.25.3"
+    "@react-native/codegen" "0.83.10"
 
 "@react-native/babel-plugin-codegen@0.83.4":
   version "0.83.4"
@@ -1797,13 +1813,56 @@
     "@babel/traverse" "^7.25.3"
     "@react-native/codegen" "0.83.4"
 
-"@react-native/babel-plugin-codegen@0.83.6":
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.83.6.tgz#4b28b951d35ecd36550c4aade1e8c1df215dd8b9"
-  integrity sha512-qfRXsHGeucT5c6mK+8Q7v4Ly3zmygfVmFlEtkiq7q07W1OTreld6nib4rJ/DBEeNiKBoBTuHjWliYGNuDjLFQA==
+"@react-native/babel-preset@0.83.10":
+  version "0.83.10"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.83.10.tgz#67411602e5cc10e1af2f5f4897565d1fcf60b9b9"
+  integrity sha512-wTZWvs5cUQqr2qBAoJNKUy6IBH7wqPAJdxTC834S/7vBqtXypYHxDAFzYXkIh8pRTC86IBYxyc2IrBYHnB8O2g==
   dependencies:
-    "@babel/traverse" "^7.25.3"
-    "@react-native/codegen" "0.83.6"
+    "@babel/core" "^7.25.2"
+    "@babel/plugin-proposal-export-default-from" "^7.24.7"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+    "@babel/plugin-syntax-export-default-from" "^7.24.7"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+    "@babel/plugin-transform-arrow-functions" "^7.24.7"
+    "@babel/plugin-transform-async-generator-functions" "^7.25.4"
+    "@babel/plugin-transform-async-to-generator" "^7.24.7"
+    "@babel/plugin-transform-block-scoping" "^7.25.0"
+    "@babel/plugin-transform-class-properties" "^7.25.4"
+    "@babel/plugin-transform-classes" "^7.25.4"
+    "@babel/plugin-transform-computed-properties" "^7.24.7"
+    "@babel/plugin-transform-destructuring" "^7.24.8"
+    "@babel/plugin-transform-flow-strip-types" "^7.25.2"
+    "@babel/plugin-transform-for-of" "^7.24.7"
+    "@babel/plugin-transform-function-name" "^7.25.1"
+    "@babel/plugin-transform-literals" "^7.25.2"
+    "@babel/plugin-transform-logical-assignment-operators" "^7.24.7"
+    "@babel/plugin-transform-modules-commonjs" "^7.24.8"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.24.7"
+    "@babel/plugin-transform-nullish-coalescing-operator" "^7.24.7"
+    "@babel/plugin-transform-numeric-separator" "^7.24.7"
+    "@babel/plugin-transform-object-rest-spread" "^7.24.7"
+    "@babel/plugin-transform-optional-catch-binding" "^7.24.7"
+    "@babel/plugin-transform-optional-chaining" "^7.24.8"
+    "@babel/plugin-transform-parameters" "^7.24.7"
+    "@babel/plugin-transform-private-methods" "^7.24.7"
+    "@babel/plugin-transform-private-property-in-object" "^7.24.7"
+    "@babel/plugin-transform-react-display-name" "^7.24.7"
+    "@babel/plugin-transform-react-jsx" "^7.25.2"
+    "@babel/plugin-transform-react-jsx-self" "^7.24.7"
+    "@babel/plugin-transform-react-jsx-source" "^7.24.7"
+    "@babel/plugin-transform-regenerator" "^7.24.7"
+    "@babel/plugin-transform-runtime" "^7.24.7"
+    "@babel/plugin-transform-shorthand-properties" "^7.24.7"
+    "@babel/plugin-transform-spread" "^7.24.7"
+    "@babel/plugin-transform-sticky-regex" "^7.24.7"
+    "@babel/plugin-transform-typescript" "^7.25.2"
+    "@babel/plugin-transform-unicode-regex" "^7.24.7"
+    "@babel/template" "^7.25.0"
+    "@react-native/babel-plugin-codegen" "0.83.10"
+    babel-plugin-syntax-hermes-parser "0.32.0"
+    babel-plugin-transform-flow-enums "^0.0.2"
+    react-refresh "^0.14.0"
 
 "@react-native/babel-preset@0.83.4":
   version "0.83.4"
@@ -1856,56 +1915,18 @@
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
 
-"@react-native/babel-preset@0.83.6":
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.83.6.tgz#e3f5ab1182768343b2b21e2f27d07773acd0bf8b"
-  integrity sha512-4/fXFDUvGOObETZq4+SUFkafld6OGgQWut5cQiqVghlhCB5z/p2lVhPgEUr/aTxTzeS3AmN+ztC+GpYPQ7tsTw==
+"@react-native/codegen@0.83.10":
+  version "0.83.10"
+  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.83.10.tgz#9e182673f9b54628b95bdfa4fee2b7f2ffb17157"
+  integrity sha512-rTcuuwRDPLrBmhXc9vAr2gispQFCEqd2WVPh2+N5eV80p8tf9mHy7CoFnmPy8A8csK6HGlANaD9SMPvccQjh4g==
   dependencies:
     "@babel/core" "^7.25.2"
-    "@babel/plugin-proposal-export-default-from" "^7.24.7"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
-    "@babel/plugin-syntax-export-default-from" "^7.24.7"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
-    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
-    "@babel/plugin-transform-arrow-functions" "^7.24.7"
-    "@babel/plugin-transform-async-generator-functions" "^7.25.4"
-    "@babel/plugin-transform-async-to-generator" "^7.24.7"
-    "@babel/plugin-transform-block-scoping" "^7.25.0"
-    "@babel/plugin-transform-class-properties" "^7.25.4"
-    "@babel/plugin-transform-classes" "^7.25.4"
-    "@babel/plugin-transform-computed-properties" "^7.24.7"
-    "@babel/plugin-transform-destructuring" "^7.24.8"
-    "@babel/plugin-transform-flow-strip-types" "^7.25.2"
-    "@babel/plugin-transform-for-of" "^7.24.7"
-    "@babel/plugin-transform-function-name" "^7.25.1"
-    "@babel/plugin-transform-literals" "^7.25.2"
-    "@babel/plugin-transform-logical-assignment-operators" "^7.24.7"
-    "@babel/plugin-transform-modules-commonjs" "^7.24.8"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.24.7"
-    "@babel/plugin-transform-nullish-coalescing-operator" "^7.24.7"
-    "@babel/plugin-transform-numeric-separator" "^7.24.7"
-    "@babel/plugin-transform-object-rest-spread" "^7.24.7"
-    "@babel/plugin-transform-optional-catch-binding" "^7.24.7"
-    "@babel/plugin-transform-optional-chaining" "^7.24.8"
-    "@babel/plugin-transform-parameters" "^7.24.7"
-    "@babel/plugin-transform-private-methods" "^7.24.7"
-    "@babel/plugin-transform-private-property-in-object" "^7.24.7"
-    "@babel/plugin-transform-react-display-name" "^7.24.7"
-    "@babel/plugin-transform-react-jsx" "^7.25.2"
-    "@babel/plugin-transform-react-jsx-self" "^7.24.7"
-    "@babel/plugin-transform-react-jsx-source" "^7.24.7"
-    "@babel/plugin-transform-regenerator" "^7.24.7"
-    "@babel/plugin-transform-runtime" "^7.24.7"
-    "@babel/plugin-transform-shorthand-properties" "^7.24.7"
-    "@babel/plugin-transform-spread" "^7.24.7"
-    "@babel/plugin-transform-sticky-regex" "^7.24.7"
-    "@babel/plugin-transform-typescript" "^7.25.2"
-    "@babel/plugin-transform-unicode-regex" "^7.24.7"
-    "@babel/template" "^7.25.0"
-    "@react-native/babel-plugin-codegen" "0.83.6"
-    babel-plugin-syntax-hermes-parser "0.32.0"
-    babel-plugin-transform-flow-enums "^0.0.2"
-    react-refresh "^0.14.0"
+    "@babel/parser" "^7.25.3"
+    glob "^7.1.1"
+    hermes-parser "0.32.0"
+    invariant "^2.2.4"
+    nullthrows "^1.1.1"
+    yargs "^17.6.2"
 
 "@react-native/codegen@0.83.4":
   version "0.83.4"
@@ -1920,25 +1941,12 @@
     nullthrows "^1.1.1"
     yargs "^17.6.2"
 
-"@react-native/codegen@0.83.6":
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.83.6.tgz#7bf0fa1a3964181c6feddb6eceab080e06168adc"
-  integrity sha512-doB/Pq6Cf6IjF3wlQXTIiZOnsX9X8mEEk+CdGfyuCwZjWrf7IB8KaZEXXckJmfUcIwvJ9u/a72ZoTTCIoxAc9A==
+"@react-native/community-cli-plugin@0.83.10":
+  version "0.83.10"
+  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.83.10.tgz#798f5893a47e81ecc99f3188ef4f5c94d6c95024"
+  integrity sha512-7QmZ7FLAIJbYjgxILBUE1k71lQB6atXZSLRczKE6Iti+BO3XHNiDSCZxuxUkYUJI0V/0kCbO/M8/a5zqHNu+Rw==
   dependencies:
-    "@babel/core" "^7.25.2"
-    "@babel/parser" "^7.25.3"
-    glob "^7.1.1"
-    hermes-parser "0.32.0"
-    invariant "^2.2.4"
-    nullthrows "^1.1.1"
-    yargs "^17.6.2"
-
-"@react-native/community-cli-plugin@0.83.6":
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.83.6.tgz#ae781a51e3b354842e12b818d5851fe69a729c39"
-  integrity sha512-Mko6mywoHYJmpBnjwAC95vQWaUUh//71knFadH0BrhHDq2m7i/IrpLwcQsPAy8855ucXflBs5zQyGTpNbPBAaw==
-  dependencies:
-    "@react-native/dev-middleware" "0.83.6"
+    "@react-native/dev-middleware" "0.83.10"
     debug "^4.4.0"
     invariant "^2.2.4"
     metro "^0.83.6"
@@ -1946,27 +1954,27 @@
     metro-core "^0.83.6"
     semver "^7.1.3"
 
-"@react-native/debugger-frontend@0.83.6":
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.83.6.tgz#0cd046f9b1eeabb9ebeaddce70e61cea70ad825d"
-  integrity sha512-TyWXEpAjVundrc87fPWg91piOUg75+X9iutcfDe7cO3NrAEYCsl7Z09rKHuiAGkxfG9/rFD13dPsYIixUFkSFA==
+"@react-native/debugger-frontend@0.83.10":
+  version "0.83.10"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.83.10.tgz#99484d1c5c9d07b5ceaa4c6a8426395bcbde3bdc"
+  integrity sha512-AlSOMdXoaSXi4O82f3APvw14e+EfrEvwPerfH2AI3JUrD/yQjFtbIxeyRPd89/MlKIbZU4cwyVFqj96bj39J5g==
 
-"@react-native/debugger-shell@0.83.6":
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-shell/-/debugger-shell-0.83.6.tgz#9770f25fff8b570cd67927ab3a83776eef26df85"
-  integrity sha512-684TJMBCU0l0ZjJWzrnK0HH+ERaM9KLyxyArE1k7BrP+gVl4X9GO0Pi94RoInOxvW/nyV65sOU6Ip1F3ygS0cg==
+"@react-native/debugger-shell@0.83.10":
+  version "0.83.10"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-shell/-/debugger-shell-0.83.10.tgz#500d609d810c9b75124d405c1c85f6a8fada3ab6"
+  integrity sha512-hk9xFI9H412XSX1lpVuKrnxUQe3zIPKxFceYPUwx2L5aZQQ/yjypWkLs+LLldV6eh93B2sBnZbns1oFSE3LQNw==
   dependencies:
     cross-spawn "^7.0.6"
     fb-dotslash "0.5.8"
 
-"@react-native/dev-middleware@0.83.6":
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.83.6.tgz#71c6d00fcf115783c4537a6e4976d79710184d21"
-  integrity sha512-22xoddLTelpcVnF385SNH2hdP7X2av5pu7yRl/WnM5jBznbcl0+M9Ce94cj+WVeomsoUF/vlfuB0Ooy+RMlRiA==
+"@react-native/dev-middleware@0.83.10":
+  version "0.83.10"
+  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.83.10.tgz#aa809a7644b84e66b38ab1b9f37b9f75153d08d2"
+  integrity sha512-V39TcESd9LGzDBs7PYVsx5oE1oGv1dLC0GIyJyEyehZjmOYk5sJ4C0m1ATKPeDE7JhiY8s/p6pNOBNp+NF4FGQ==
   dependencies:
     "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "0.83.6"
-    "@react-native/debugger-shell" "0.83.6"
+    "@react-native/debugger-frontend" "0.83.10"
+    "@react-native/debugger-shell" "0.83.10"
     chrome-launcher "^0.15.2"
     chromium-edge-launcher "^0.2.0"
     connect "^3.6.5"
@@ -1977,30 +1985,30 @@
     serve-static "^1.16.2"
     ws "^7.5.10"
 
-"@react-native/gradle-plugin@0.83.6":
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.83.6.tgz#db33a052f7629828222472e63817f3cc92ec8552"
-  integrity sha512-5prXv7WWR1RgZ/kWGZP+mi7/y/IE2ymfOHIZO5Pv14tMOmRAcQSgSYogcRmOiWw5mJs2K0UFeMiQD49ZO9oCug==
+"@react-native/gradle-plugin@0.83.10":
+  version "0.83.10"
+  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.83.10.tgz#d75d957558e1173573ffa81eb8368d597102e2e3"
+  integrity sha512-DpWzrcmxAEgD/tvy4r4WH10PYJPdfDCvtctVZ2Ez0sHlNYgWI6STfqxeAcZhU84hMhNsTec3IHDxNJ2cG8xPjQ==
 
-"@react-native/js-polyfills@0.83.6":
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.83.6.tgz#401bcdbedf526317943b538af7bb99d70aa96b54"
-  integrity sha512-VSev0LV2i5X0ibduHBSLqKj0YU2F+waCgjl2uvaGHMGCSV1ZRKNFX/vJFqvLwjvdzLbkAZoFT1Rg7k7jDv44UA==
+"@react-native/js-polyfills@0.83.10":
+  version "0.83.10"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.83.10.tgz#388ee07dd50b0fb1a863d3d811131985b570a8ae"
+  integrity sha512-q28LKHga5lf2ZX4u1T8Bj5RXqyzOBRWSXVjCCdczj/oacAVZPUrandGC1E9fR35fujyb3ZCqZbIQCvs8MhsTNA==
 
-"@react-native/normalize-colors@0.83.6":
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.83.6.tgz#9fef0e98733d58267aecafede08ebcc830a29c82"
-  integrity sha512-bTM24b5v4qN3h52oflnv+OujFORn/kVi06WaWhnQQw14/ycilPqIsqsa+DpIBqdBrXxvLa9fXtCRrQtGATZCEw==
+"@react-native/normalize-colors@0.83.10":
+  version "0.83.10"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.83.10.tgz#231d542e5b409d280230cfdd3274eecd68d196b4"
+  integrity sha512-dWgqcxaBy27oLx9tndcTF0917vbLOOstyNjYD58J6Z7YxkEZSaKG6+A+3I1KV6O1Xg2D69QThp4t6ezoC3NiGA==
 
 "@react-native/normalize-colors@^0.74.1":
   version "0.74.89"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.74.89.tgz#b8ac17d1bbccd3ef9a1f921665d04d42cff85976"
   integrity sha512-qoMMXddVKVhZ8PA1AbUCk83trpd6N+1nF2A6k1i6LsQObyS92fELuk8kU/lQs6M7BsMHwqyLCpQJ1uFgNvIQXg==
 
-"@react-native/virtualized-lists@0.83.6":
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.83.6.tgz#db5c2a7280519c6bea6c77a84cd70cd106a79f87"
-  integrity sha512-gNSFXeb4P7qHtauLvl+zESroULIyX6Ltpvau3dhwy/QmfanBv0KUcrIU/7aVXxtWcXgp+54oWJyu2LIrsZ9+LQ==
+"@react-native/virtualized-lists@0.83.10":
+  version "0.83.10"
+  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.83.10.tgz#e372aeb232fb5eae85da5803ea6db5431057f63a"
+  integrity sha512-KNX6jCYcCnOKfoJyGMcgDrAVaQXOuNymBi2UC9sf2msEmgkrGgoWa+eKiATqaCgN44UFKlJIuNj4wUPTCWzZ0Q==
   dependencies:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
@@ -3059,10 +3067,10 @@ babel-preset-current-node-syntax@^1.0.0, babel-preset-current-node-syntax@^1.2.0
     "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
     "@babel/plugin-syntax-top-level-await" "^7.14.5"
 
-babel-preset-expo@~55.0.22:
-  version "55.0.22"
-  resolved "https://registry.yarnpkg.com/babel-preset-expo/-/babel-preset-expo-55.0.22.tgz#8eb9b7566589d59b294374522d34ceb39d1cfe01"
-  integrity sha512-Se6kPnvCNN13jJVIa6JJvlmImVoVRzu9stagAbivCPcfrq2VNrsEiYpJZ1+H32kXinKW/y797/wctGuxPy0APw==
+babel-preset-expo@~55.0.24:
+  version "55.0.24"
+  resolved "https://registry.yarnpkg.com/babel-preset-expo/-/babel-preset-expo-55.0.24.tgz#ef902132cdbe365a88c2e03b43cbaa3523c3eec0"
+  integrity sha512-dzjg70cq3Ls5msL79GSktjqtbjzXh/r5errxz8aD97S180pkXrMga22ozrcNhHddMBtZGDKN2jBK1FS1RLkfBQ==
   dependencies:
     "@babel/generator" "^7.20.5"
     "@babel/helper-module-imports" "^7.25.9"
@@ -3080,7 +3088,7 @@ babel-preset-expo@~55.0.22:
     "@babel/plugin-transform-runtime" "^7.24.7"
     "@babel/preset-react" "^7.22.15"
     "@babel/preset-typescript" "^7.23.0"
-    "@react-native/babel-preset" "0.83.6"
+    "@react-native/babel-preset" "0.83.10"
     babel-plugin-react-compiler "^1.0.0"
     babel-plugin-react-native-web "~0.21.0"
     babel-plugin-syntax-hermes-parser "^0.32.0"
@@ -3781,10 +3789,10 @@ diff@^8.0.3:
   resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.4.tgz#4f5baf3188b9b2431117b962eb20ba330fadf696"
   integrity sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==
 
-dnssd-advertise@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/dnssd-advertise/-/dnssd-advertise-1.1.4.tgz#0744865a4fa2569a44dcb9aff267022aaf2803b2"
-  integrity sha512-AmGyK9WpNf06WeP5TjHZq/wNzP76OuEeaiTlKr9E/EEelYLczywUKoqRz+DPRq/ErssjT4lU+/W7wzJW+7K/ZA==
+dnssd-advertise@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/dnssd-advertise/-/dnssd-advertise-1.1.6.tgz#47a543d25ec133dcca0a77468baaacc6987bbcc8"
+  integrity sha512-Ndrrf6BMPalkQPd/zubL+4YghH2J9NspapQ09uDXwYbvOPkP0oaqf5CkcwJ0b50kS2O3ul6yVu+jz+RY62Cejg==
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -4297,76 +4305,76 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
-expo-application@~55.0.15:
-  version "55.0.15"
-  resolved "https://registry.yarnpkg.com/expo-application/-/expo-application-55.0.15.tgz#5ae5484baa94c69a6eda92757c8e76be035a628d"
-  integrity sha512-eWf5OGrat1r/TYr0daL684C6pJYiN2k30NmcISsD9fbtZLfA6Sbo/JebfYzP3OjO/T/i8j/9Pf3ePqUYPLfZnw==
-
-expo-asset@~55.0.17:
+expo-application@~55.0.17:
   version "55.0.17"
-  resolved "https://registry.yarnpkg.com/expo-asset/-/expo-asset-55.0.17.tgz#750a27685ea118417473f4f293c5a35116b572d4"
-  integrity sha512-pK9HHJuFqjE8kDUcbMFsZj3Cz8WdXpvZHZmYl7ouFQp59P83BvHln6VnqPDGlO+/4929G0Lm8ZUzbONuNRhi9w==
-  dependencies:
-    "@expo/image-utils" "^0.8.14"
-    expo-constants "~55.0.16"
+  resolved "https://registry.yarnpkg.com/expo-application/-/expo-application-55.0.17.tgz#91d5d4872c78dc1ae1752cce5359e9343bee5b5d"
+  integrity sha512-ASuZe+Sl8ax+0pQOjd8L5cz5xpxW0F1VSorRKFr9LHxDSQwH929nYjbMrvW6KlRIIWZBIAQQsYqWiowytCLMRA==
 
-expo-audio@~55.0.14:
-  version "55.0.14"
-  resolved "https://registry.yarnpkg.com/expo-audio/-/expo-audio-55.0.14.tgz#2a2b8f420eb860f15f2de9ffaedf21156139a889"
-  integrity sha512-Biy6ffKXrnKHgcWSVWLKVdWLNhV/pj1JWJeotY6nDR6fVe8mjXQDCvi6EbaSFPdffVHym6UB2siKzWUNSnG+kQ==
-
-expo-build-properties@~55.0.14:
-  version "55.0.14"
-  resolved "https://registry.yarnpkg.com/expo-build-properties/-/expo-build-properties-55.0.14.tgz#2906668de26b0eac4956829ec15c4cf043e34d1b"
-  integrity sha512-5wopuLXlzFpDnCfsIjgAcj4yKnVTYg3XYGnYV5Hqi7u6jJipLG4fwtUqxVIFqBj7vEHXjd4zYCyXjp39AtAD7w==
+expo-asset@~55.0.18:
+  version "55.0.18"
+  resolved "https://registry.yarnpkg.com/expo-asset/-/expo-asset-55.0.18.tgz#70887680fb4d80ec599d4e92ea30d1079eb929a4"
+  integrity sha512-dbNMcBE0AaFbdxjBSRgDLdtOi8PHt9CQOg+J3EdeXNPKZCDO88kvaHcXaYUMmkbN2KJYQlfu1GxfUVAIoi7iVQ==
   dependencies:
-    "@expo/schema-utils" "^55.0.4"
+    "@expo/image-utils" "^0.8.15"
+    expo-constants "~55.0.17"
+
+expo-audio@~55.0.16:
+  version "55.0.16"
+  resolved "https://registry.yarnpkg.com/expo-audio/-/expo-audio-55.0.16.tgz#72add2bb02218019f9c63e994af73415d00b61da"
+  integrity sha512-PBRSqMibeRh/7AgoentfEol9Y8fYUkGC4hcKphaOsmt2BaXBcHgLUHwV+p41BH4kyqxJAedLXI9MH44xq1biDg==
+
+expo-build-properties@~55.0.16:
+  version "55.0.16"
+  resolved "https://registry.yarnpkg.com/expo-build-properties/-/expo-build-properties-55.0.16.tgz#bc03e155bc47d0f04d05c75a88c30910eec1c189"
+  integrity sha512-i8vRqvbGQHfNGMx9iKKtJzK3/KODD2HsOIBrzQGns3ShwMc/6+J6kHDBpph6BpDAWihi6kY7VIDMKiN7ov8PhQ==
+  dependencies:
+    "@expo/schema-utils" "^55.0.5"
     resolve-from "^5.0.0"
     semver "^7.6.0"
 
-expo-constants@~55.0.16:
-  version "55.0.16"
-  resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-55.0.16.tgz#b2ffdc354716488aa38684c8cbf097150089b9b7"
-  integrity sha512-Z15/No94UHoogD+pulxjudGAeOHTEIWZgb/vnX48Wx5D+apWTeCbnKxQZZtGQlosvduYL5kaic2/W8U+NHfBQQ==
+expo-constants@~55.0.17:
+  version "55.0.17"
+  resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-55.0.17.tgz#cf77d27f3b74a46da2cd40ed1785fcc335ded374"
+  integrity sha512-t0SNWmXTjXPCHzjNsv1Okjaj8SpXQcUjDPtYDqvofDS+BhAsvlKNmwaaWXvduBjjmmmJWNH8q1/x9IWQ+upg8g==
   dependencies:
-    "@expo/env" "~2.1.2"
+    "@expo/env" "~2.1.3"
 
-expo-dev-client@~55.0.35:
-  version "55.0.35"
-  resolved "https://registry.yarnpkg.com/expo-dev-client/-/expo-dev-client-55.0.35.tgz#93bc40edcc6724e633396c53fec53b77423e205f"
-  integrity sha512-DN50x9gqWYAfnJpxgiJm3zK2bFvDhxJ5JjFq0wFot7o4knZ7H3BVwiL6zZMHG29g6gfxdgpzGG69WPiSR/Ipgg==
+expo-dev-client@~55.0.37:
+  version "55.0.37"
+  resolved "https://registry.yarnpkg.com/expo-dev-client/-/expo-dev-client-55.0.37.tgz#8f75528e813a60ad2ca2881143f5081b6c661fce"
+  integrity sha512-FA5dMuo653p02fAG4gWRSRaERP3jXIfpVngAE2F9pZLe0wHHJAbIlNWrr+TdaIRQ0xX02FTyLkXOgxvxSqku2w==
   dependencies:
-    expo-dev-launcher "55.0.36"
-    expo-dev-menu "55.0.30"
+    expo-dev-launcher "55.0.38"
+    expo-dev-menu "55.0.32"
     expo-dev-menu-interface "55.0.2"
-    expo-manifests "~55.0.17"
+    expo-manifests "~55.0.19"
     expo-updates-interface "~55.1.6"
 
-expo-dev-launcher@55.0.36:
-  version "55.0.36"
-  resolved "https://registry.yarnpkg.com/expo-dev-launcher/-/expo-dev-launcher-55.0.36.tgz#9e2f008aa4ba06798e8340642aafaac87b78dbf5"
-  integrity sha512-Dn2om4J71aavWqi1jLzK3QlGZjDiFv7nIBZkQyzy2zW62IOD9kLwOOvHHj07Ra/6n9cqFEpNYzwpPkR7KHuYZA==
+expo-dev-launcher@55.0.38:
+  version "55.0.38"
+  resolved "https://registry.yarnpkg.com/expo-dev-launcher/-/expo-dev-launcher-55.0.38.tgz#ff6a4193f4daee2642c26463197e76150d299610"
+  integrity sha512-i7KX1b0YUcjpSHbr9xOpGF8FPr2+41ZQJPqtKEzuYtMgtCEDonUDpvSbEEE5RDxywxKqrV6hKtV058ncv0gAbw==
   dependencies:
-    "@expo/schema-utils" "^55.0.4"
-    expo-dev-menu "55.0.30"
-    expo-manifests "~55.0.17"
+    "@expo/schema-utils" "^55.0.5"
+    expo-dev-menu "55.0.32"
+    expo-manifests "~55.0.19"
 
 expo-dev-menu-interface@55.0.2:
   version "55.0.2"
   resolved "https://registry.yarnpkg.com/expo-dev-menu-interface/-/expo-dev-menu-interface-55.0.2.tgz#aead1b9980c904d61c59e9182e13b2b37bcb2161"
   integrity sha512-DomUNvGzY/xliwnMdbAYY780sCv19N7zIbifc0ClcoCzJZpNSCkvJ2qGIFRPyM/7DmqmlHGCKi8di7kYYLKNEg==
 
-expo-dev-menu@55.0.30:
-  version "55.0.30"
-  resolved "https://registry.yarnpkg.com/expo-dev-menu/-/expo-dev-menu-55.0.30.tgz#3da5185de7ad31ff63497ebc506526c7a4e0eb26"
-  integrity sha512-uwDI4cEPzpRemf06Ts5O41azJcz8BBcE6QOkNaTX8JlzdJ05eq9jWxmbA1WhoSoE5C+NFo8njHSvmHqUqTpOng==
+expo-dev-menu@55.0.32:
+  version "55.0.32"
+  resolved "https://registry.yarnpkg.com/expo-dev-menu/-/expo-dev-menu-55.0.32.tgz#d6b9bacb3eb0a89546fb695cf1a543ca25e9f552"
+  integrity sha512-4PlXKz9iDVqGpkRKPKxkDQdzg/snpRqPIHagsnGx1h29fxXwmeuZzC/Bju8aZkMcAXCNdgCDHjyjp7Ff5jCbdg==
   dependencies:
     expo-dev-menu-interface "55.0.2"
 
-expo-device@~55.0.17:
-  version "55.0.17"
-  resolved "https://registry.yarnpkg.com/expo-device/-/expo-device-55.0.17.tgz#703fb93f69fab62de9deaad9bd1fb9031d8496a3"
-  integrity sha512-ZcMrSeD0zWooosm5Bet5qluxUrhw+NPgcMmN6ySVF7cm4K8Bvh4KPogJePbI1qfhFAiJWcWeV9e/2uewb9ktfw==
+expo-device@~55.0.19:
+  version "55.0.19"
+  resolved "https://registry.yarnpkg.com/expo-device/-/expo-device-55.0.19.tgz#c125ab93f35568782a575799f28267bdb488073d"
+  integrity sha512-BYEr3oyjtnXk432usxavftybCtucelCQD1QGIo2zruxeT/hzoGe36uclOC49a+tYFQoybqOylSV2035H7kDIPg==
   dependencies:
     ua-parser-js "^0.7.33"
 
@@ -4380,10 +4388,10 @@ expo-eas-client@~55.0.5:
   resolved "https://registry.yarnpkg.com/expo-eas-client/-/expo-eas-client-55.0.5.tgz#36e09e6c9e161eb72c17ce1657af210f6a9e4389"
   integrity sha512-wRagCeSbSnSGVXgP7V+qiGfXzZ9hTVKWvKIOP7lwrX3MIEenNmNlO4D3RVC3aNU2GhmO3ZCZIIEre80KZoUUHA==
 
-expo-file-system@~55.0.22:
-  version "55.0.22"
-  resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-55.0.22.tgz#99d69628dbdc622dc592ff46416e563cc1a6c3f5"
-  integrity sha512-T5Rfv3vqcFyhVrl/tEEeglc/J8LJbcZQgC3TMT5jxzIgUgWmIgJEgncGYqB/YNXFgUTL2LiuCvqrU51Dzp83NQ==
+expo-file-system@~55.0.24:
+  version "55.0.24"
+  resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-55.0.24.tgz#71d0559705069db89932e4b98b4e97ef3ea80867"
+  integrity sha512-7/HJdvaaf3kP5T3atd+6Q0/QexrGio4Fs2GVtp7G8d/xQCSu01yeGReu7tGQo9VAM67Snq+ujGlL8q2wbMXLkQ==
 
 expo-font@~55.0.8:
   version "55.0.8"
@@ -4392,34 +4400,29 @@ expo-font@~55.0.8:
   dependencies:
     fontfaceobserver "^2.1.0"
 
-expo-image-loader@~55.0.0:
-  version "55.0.0"
-  resolved "https://registry.yarnpkg.com/expo-image-loader/-/expo-image-loader-55.0.0.tgz#56ae6631a0f43191432296a1f7f1e9737e653cfe"
-  integrity sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ==
-
 expo-image-loader@~55.0.1:
   version "55.0.1"
   resolved "https://registry.yarnpkg.com/expo-image-loader/-/expo-image-loader-55.0.1.tgz#2c6bdae78e312d40aff12639c5d9a0189dbee6cf"
   integrity sha512-o8gCo1j59XpXDh0/llgNYPcnfecYQhafQAO0yw5pb+kukPizvNoEqea8tFQIIQmNYqxd6Ljgs7lLXed0gXpOdQ==
 
-expo-image-manipulator@~55.0.17:
-  version "55.0.17"
-  resolved "https://registry.yarnpkg.com/expo-image-manipulator/-/expo-image-manipulator-55.0.17.tgz#64c1fa612e7fd1334906d17253d5304f630b5227"
-  integrity sha512-lTYhmXejHnMp+vjFID0Q/jD+Qic3U9OP4qw3tCVHCVp4TTmx9hbifTIN0hmw02ak7LsBkxuYnP+uglvUKgJAzA==
+expo-image-manipulator@~55.0.19:
+  version "55.0.19"
+  resolved "https://registry.yarnpkg.com/expo-image-manipulator/-/expo-image-manipulator-55.0.19.tgz#03315fdead3ce48287a024c120606eb1da6509d9"
+  integrity sha512-oYd3rKepUyZUQudrWaVwC+EUHzLa5pL+Oq4eBjZWvDIqvtEagq0sSch4XQsIKcB3ym19DCJORQapAW0YnBtAXg==
   dependencies:
     expo-image-loader "~55.0.1"
 
-expo-image-picker@~55.0.20:
-  version "55.0.20"
-  resolved "https://registry.yarnpkg.com/expo-image-picker/-/expo-image-picker-55.0.20.tgz#42660178a00371df03f5633856dbaad36fec96ee"
-  integrity sha512-lfWt/0rPWdKz8AdDEGmGHZIJSNlVc720Dlx5bfou10FU16ZV5wAbTU63nm2jkXd8hbXke4a/2Ha1dzxCVA+LQQ==
+expo-image-picker@~55.0.22:
+  version "55.0.22"
+  resolved "https://registry.yarnpkg.com/expo-image-picker/-/expo-image-picker-55.0.22.tgz#456ec2a2bf90f6c60725fdd16bc993592a3cfb29"
+  integrity sha512-pO/CJ2kjZ6HFSEjVlBMF7TiQVHai3M4itkWP9EklQP/grJGN6X4Yd4LK6acRwpkC+Icn7kiJhxN5sXgxNanXHA==
   dependencies:
-    expo-image-loader "~55.0.0"
+    expo-image-loader "~55.0.1"
 
-expo-intent-launcher@~55.0.12:
-  version "55.0.12"
-  resolved "https://registry.yarnpkg.com/expo-intent-launcher/-/expo-intent-launcher-55.0.12.tgz#9bd122c821514a3d59c1348c887de28c31b25293"
-  integrity sha512-Mo94T8rq1bFSiXX8vR/2U5xIlrbGnXXqT6gfp/fsR5IsBBog3Jf2MbSvAfqj78Z/ho5LK3d/PXJjCOONFqXZ2A==
+expo-intent-launcher@~55.0.14:
+  version "55.0.14"
+  resolved "https://registry.yarnpkg.com/expo-intent-launcher/-/expo-intent-launcher-55.0.14.tgz#c2f5c3b336c16627f4881e4fd6ada2b4f99e8ad7"
+  integrity sha512-I1bh7iYoe4oHxkiM+Cuajl6UEVB5uXbufOTPKOyRQ4Qkcw3WOYpOHekOvwHwt1MpEOant7l4ACYeoe3ptM+sBw==
 
 expo-json-utils@~55.0.2:
   version "55.0.2"
@@ -4431,24 +4434,24 @@ expo-keep-awake@~55.0.8:
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-55.0.8.tgz#007e9ab9508c6e9dc606be6ceb7bbd2036c7ac58"
   integrity sha512-PfIpMfM+STOBwkR5XOE+yVtER86c44MD+W8QD8JxuO0sT9pF7Y1SJYakWlpvX8xsGA+bjKLxftm9403s9kQhKA==
 
-expo-linear-gradient@~55.0.14:
-  version "55.0.14"
-  resolved "https://registry.yarnpkg.com/expo-linear-gradient/-/expo-linear-gradient-55.0.14.tgz#a7714e3b94223a1d1cea21bc24e5c8ecbfdce823"
-  integrity sha512-n01A9P0ZebRo8Rm4QHYEjMR8z4Y6MBc8uVnT8NB9cOJislvEmz2o2WQJoK6RD7FjoeFEW8KkRtggK7fQ3h7KIg==
+expo-linear-gradient@~55.0.16:
+  version "55.0.16"
+  resolved "https://registry.yarnpkg.com/expo-linear-gradient/-/expo-linear-gradient-55.0.16.tgz#fb45e08bb7fd6ab31878c429e577416b0f51041e"
+  integrity sha512-zzNB2Hdv+i3zIO8GPN1oU6BeqRJXQSwKgmdJXNf735Fsplxk1bjmqdYNXHamge7uHTb6M+X6aY9Mtjbrf/4S2g==
 
-expo-manifests@~55.0.17:
-  version "55.0.17"
-  resolved "https://registry.yarnpkg.com/expo-manifests/-/expo-manifests-55.0.17.tgz#6f709f8732341a751db6959a824ea995009bec46"
-  integrity sha512-vKZvFivX3usVJKfBODKQcFHso0g38zlGbRGqGAppz+il0zKvG6umpJ47OZbzLod7iJpjd+ZDD2AGuOxacixonA==
+expo-manifests@~55.0.19:
+  version "55.0.19"
+  resolved "https://registry.yarnpkg.com/expo-manifests/-/expo-manifests-55.0.19.tgz#322a17632200be72bcba8bccb65193c873e4d27c"
+  integrity sha512-NmIoGapFzTTZhR46loLqTTnZfL8C6GQdQA47q1NjWiT3UeUPrGUrK7CEASMdhCFxaymkpbRFsbMECeSq6knIPg==
   dependencies:
     expo-json-utils "~55.0.2"
 
-expo-modules-autolinking@55.0.24:
-  version "55.0.24"
-  resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-55.0.24.tgz#1751f07c0dbbc7fe7c6fc9fe2194fef79ef8c335"
-  integrity sha512-A0OyMbTPZqibYrwqj98HFYTNSvl4NSS4Zt+R5A8qiAx3nM0mc81e6Iqw7Wl4J8M/t36lJ+cT3WuVTz5Oszj6Hw==
+expo-modules-autolinking@55.0.25:
+  version "55.0.25"
+  resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-55.0.25.tgz#4f929f6cfb76bad53bf1c79880eecb811163e6b6"
+  integrity sha512-qO8se6zTxfdCGeuwc0dCTmnstW5r1tKSr9SoWtZn0mhlr5Qe5RSJa0vhzQ32eIwgMd77GJrc1yJtkktgN817vg==
   dependencies:
-    "@expo/require-utils" "^55.0.5"
+    "@expo/require-utils" "^55.0.6"
     "@expo/spawn-async" "^1.7.2"
     chalk "^4.1.0"
     commander "^7.2.0"
@@ -4460,59 +4463,59 @@ expo-modules-core@55.0.25:
   dependencies:
     invariant "^2.2.4"
 
-expo-notifications@~55.0.23:
-  version "55.0.23"
-  resolved "https://registry.yarnpkg.com/expo-notifications/-/expo-notifications-55.0.23.tgz#bef07ca66f7c559110765e3c3673cdc5d395f2c5"
-  integrity sha512-oWEsBZSedRFu+ErcJaIev7QQhCE/gTRO6KURAkFpMflMgI3yjT4O/qixXh4tHmEk5zfoOpR2u79AzvVcchfwww==
+expo-notifications@~55.0.25:
+  version "55.0.25"
+  resolved "https://registry.yarnpkg.com/expo-notifications/-/expo-notifications-55.0.25.tgz#afce55202f71a31287e0bb1d8f78a92530681d09"
+  integrity sha512-yCbZElqHLvGommwMXJn0ZS/8kJ8wbf7Ujn5or4lVGthRUhaRZfTrN/UJlc9FnQmuKJ35I4rSzo1fqeQjxb+XOw==
   dependencies:
-    "@expo/image-utils" "^0.8.14"
+    "@expo/image-utils" "^0.8.15"
     abort-controller "^3.0.0"
     badgin "^1.1.5"
-    expo-application "~55.0.15"
-    expo-constants "~55.0.16"
+    expo-application "~55.0.17"
+    expo-constants "~55.0.17"
 
-expo-print@~55.0.15:
-  version "55.0.15"
-  resolved "https://registry.yarnpkg.com/expo-print/-/expo-print-55.0.15.tgz#1a5d9d78c1021e5201b5c97c79eedc9712d73bae"
-  integrity sha512-poo/RB8Bzoqi2jCeAqmHJFib07GMx41FPmQCNSb/NI+1KC5kucW/2VCRXKzwgVofdwFYMJbg04ewiA8YpY8PCQ==
+expo-print@~55.0.17:
+  version "55.0.17"
+  resolved "https://registry.yarnpkg.com/expo-print/-/expo-print-55.0.17.tgz#fe8b467e52db0e9f5be2cbea04400e7e38c14348"
+  integrity sha512-PZMuiaJzHNZvv+u9/EVsyDbP6NYeX4ZKEUN1SxNOIHfklFnrwOH5t3R534yKh1qHBbSvQ4Nbn965rpVTqAltdA==
 
-expo-screen-orientation@~55.0.16:
-  version "55.0.16"
-  resolved "https://registry.yarnpkg.com/expo-screen-orientation/-/expo-screen-orientation-55.0.16.tgz#fb995bfa5f6aaeb6c733cb040e324f3a9278be50"
-  integrity sha512-I9NIqb2zAkHsK/CxdmMdmgSFP7E1v++8z/Mj2X9j1AuK6l55yOma/JHo905KU3x2zPm9/l1BTzmMA320tiBebg==
+expo-screen-orientation@~55.0.18:
+  version "55.0.18"
+  resolved "https://registry.yarnpkg.com/expo-screen-orientation/-/expo-screen-orientation-55.0.18.tgz#d4d7e50a6a2abeb9984150130c438246c6a98193"
+  integrity sha512-Y/u4rTUoxQVyW2kAgqljgxd1HmRvALhFZLMxcDvY1aclhh29PcA0JzvCXO1mVixidOv5WFDtOFROUkA6C7FhFA==
 
 expo-server@^55.0.11:
   version "55.0.11"
   resolved "https://registry.yarnpkg.com/expo-server/-/expo-server-55.0.11.tgz#6850ea1aac47a735fd7908023fe9be8b75fc49d9"
   integrity sha512-AxRdHqcv0H1g4s923vu+5n1Nrhne23bjXbP+Vl7+Lwfpe7MG9PuU1IS95IJK6a+7BVV1mRN6QlZvs8Yv7EEXNQ==
 
-expo-sharing@~55.0.20:
-  version "55.0.20"
-  resolved "https://registry.yarnpkg.com/expo-sharing/-/expo-sharing-55.0.20.tgz#918da84efc530b95f5f00f8e93f37ac7117a70f6"
-  integrity sha512-KhDCsqPmDFFEWM+NlJe+nn0Z48hYeprNpwtNa5wQ4JgXxr2FL7i+AXjLh6v6kdHO2+r6+gkDft/u4fTDgYXdtA==
+expo-sharing@~55.0.22:
+  version "55.0.22"
+  resolved "https://registry.yarnpkg.com/expo-sharing/-/expo-sharing-55.0.22.tgz#49d0e68f0406b1d8d771e91641ed488802e9f595"
+  integrity sha512-52s4FfjNMLJfKl4wxakRjbrfgya3w7XZ15tCc/7IVH2HX/q467mePBS1VqYWbuuKDjvDAL02Aj2LcFaUNwkoWQ==
   dependencies:
-    "@expo/config-plugins" "^55.0.10"
-    "@expo/config-types" "^55.0.5"
+    "@expo/config-plugins" "^55.0.11"
+    "@expo/config-types" "^55.0.6"
     "@expo/plist" "^0.5.4"
 
-expo-splash-screen@~55.0.21:
-  version "55.0.21"
-  resolved "https://registry.yarnpkg.com/expo-splash-screen/-/expo-splash-screen-55.0.21.tgz#0a8f465ebd6eab4f388fb917cde20db4dcc3709c"
-  integrity sha512-hFGEap69ggCckbHIdDXMe5rqfBR9TwcnY5gBhyaACUxU64w827T6prOQcIvLmAdv00kp3Gqt7hgE+mNn37EF+A==
+expo-splash-screen@~55.0.23:
+  version "55.0.23"
+  resolved "https://registry.yarnpkg.com/expo-splash-screen/-/expo-splash-screen-55.0.23.tgz#f415dae63f102aa8906b68515480e88fcdc9010f"
+  integrity sha512-gvxl1bWvcxWwr8Hd5hMjCkOYIgK+IY0tEFSLlhvVJIKr2vMUkz1RYMgC4732lhn4PZXvwjeFUsREvjzGMRsuqA==
   dependencies:
-    "@expo/prebuild-config" "^55.0.18"
+    "@expo/prebuild-config" "^55.0.20"
 
 expo-structured-headers@~55.0.2:
   version "55.0.2"
   resolved "https://registry.yarnpkg.com/expo-structured-headers/-/expo-structured-headers-55.0.2.tgz#02705fae72add7bb91859d4c91ef38b07eefa676"
   integrity sha512-KITovrWigTOtsII5hRQ9/3ydaNcxCux5g6O+eTPLyjnye9dpkDKl5GmCLVPVKIL/d7253OtbGtWMD4m0gha5pw==
 
-expo-system-ui@~55.0.18:
-  version "55.0.18"
-  resolved "https://registry.yarnpkg.com/expo-system-ui/-/expo-system-ui-55.0.18.tgz#dabd6c872e4c71d12e6ba512733be8f5387a2028"
-  integrity sha512-Fbc0HJgqMpABeA/gI7NJFnSXwUeLrEMjjXq8Nl+4gTXyacIK2iOOrzCkvq41rKBBde0CR6kVnB1DXj0j9ZYnjg==
+expo-system-ui@~55.0.20:
+  version "55.0.20"
+  resolved "https://registry.yarnpkg.com/expo-system-ui/-/expo-system-ui-55.0.20.tgz#436219d6b525a3f973f7b77a603f4a064ae19345"
+  integrity sha512-XpfnBhB7Jbj4QjqzLVFXekQWsc98lhowiA7yNNk5bj+U9iIpXjw+oK7tqUisT0eeScKpT5jY5QaffZFeUtDA3g==
   dependencies:
-    "@react-native/normalize-colors" "0.83.6"
+    "@react-native/normalize-colors" "0.83.10"
     debug "^4.3.2"
 
 expo-updates-interface@~55.1.6:
@@ -4520,10 +4523,10 @@ expo-updates-interface@~55.1.6:
   resolved "https://registry.yarnpkg.com/expo-updates-interface/-/expo-updates-interface-55.1.6.tgz#18a806d65a28229ed4a7f920fceb9dda678c5c09"
   integrity sha512-evxNpagCkjT3lE6bGV570TFzRtKuIuLY8I37RYHoriXCJ+ZKCN1hbmklK29uAixya+BxGpeTI2K4FqYeJLvfrw==
 
-expo-updates@~55.0.24:
-  version "55.0.24"
-  resolved "https://registry.yarnpkg.com/expo-updates/-/expo-updates-55.0.24.tgz#1dc0d0792a054447888d7ad94b87097033739d1f"
-  integrity sha512-aqbsRT5GyKG8++RndIb4+jFUknsPgqWImzYUG20PiPjwPlQ25MSfz5+r1IAI8YfvGuLRIIRt8yDQ2Ob+RV+fyg==
+expo-updates@~55.0.26:
+  version "55.0.26"
+  resolved "https://registry.yarnpkg.com/expo-updates/-/expo-updates-55.0.26.tgz#6df769c54af1c9afaeef0f23d07c200f1058734b"
+  integrity sha512-Ham6Knj1YNQBJxgz8sO/VwaHwNRPl4VM5X8vajO2Exfd6LpoIXCXy4pTAJYC8eaTiM47yFZV+nuNXXO0DokefQ==
   dependencies:
     "@expo/code-signing-certificates" "^0.0.6"
     "@expo/plist" "^0.5.4"
@@ -4532,7 +4535,7 @@ expo-updates@~55.0.24:
     chalk "^4.1.2"
     debug "^4.3.4"
     expo-eas-client "~55.0.5"
-    expo-manifests "~55.0.17"
+    expo-manifests "~55.0.19"
     expo-structured-headers "~55.0.2"
     expo-updates-interface "~55.1.6"
     getenv "^2.0.0"
@@ -4540,35 +4543,35 @@ expo-updates@~55.0.24:
     ignore "^5.3.1"
     resolve-from "^5.0.0"
 
-expo-video@~55.0.17:
-  version "55.0.17"
-  resolved "https://registry.yarnpkg.com/expo-video/-/expo-video-55.0.17.tgz#9bb049a93a50c55477cb9d228442ae52a80cb636"
-  integrity sha512-z2Fqg1WkctD2jpsUoMQU9y6jWYlV+Lwb7nIMB+3fOcKMVCiUwSWS9xq/MQnRImZe6t9gfRFVMvw2Xz8Lk/kUPw==
+expo-video@~55.0.19:
+  version "55.0.19"
+  resolved "https://registry.yarnpkg.com/expo-video/-/expo-video-55.0.19.tgz#65b39e9bb09bba2997b648fe2e507a7e82a34a5c"
+  integrity sha512-/B3aDy+cAGYdtpQa2RSxZGnm2kj53iEKKsZUwaA1I959bkeWFxrjQw0L58RGQhorS5PAImNWH4GSA9b5IslOyg==
 
-expo@~55.0.26:
-  version "55.0.26"
-  resolved "https://registry.yarnpkg.com/expo/-/expo-55.0.26.tgz#6ec75169ec34d3d62ee38f0b1afc0911b1a4858a"
-  integrity sha512-MuVW6Uzd/Jh6E37ICOYAiTOm9nflNMUNzf6wH5ld/IXFyuF2Lo86a8fCSMgHcvTGsSjRsJ5Uxhf+WHZcvGPfrg==
+expo@~55.0.28:
+  version "55.0.28"
+  resolved "https://registry.yarnpkg.com/expo/-/expo-55.0.28.tgz#b9d61ac64a1df47ee70f8dc7b7e437f2848e8c22"
+  integrity sha512-rKWG+gjM4e+nJ6UUXn+jhs1+2lkzwLHjUZL9U4ejN3mLtqU9sOYvX925tOaD/lu3847LoZ8i5GJiyqu3tmK7Lg==
   dependencies:
     "@babel/runtime" "^7.20.0"
-    "@expo/cli" "55.0.32"
-    "@expo/config" "~55.0.17"
-    "@expo/config-plugins" "~55.0.10"
+    "@expo/cli" "55.0.34"
+    "@expo/config" "~55.0.19"
+    "@expo/config-plugins" "~55.0.11"
     "@expo/devtools" "55.0.3"
-    "@expo/fingerprint" "0.16.7"
-    "@expo/local-build-cache-provider" "55.0.13"
-    "@expo/log-box" "55.0.12"
+    "@expo/fingerprint" "0.16.8"
+    "@expo/local-build-cache-provider" "55.0.15"
+    "@expo/log-box" "55.0.13"
     "@expo/metro" "~55.1.1"
-    "@expo/metro-config" "55.0.23"
+    "@expo/metro-config" "55.0.25"
     "@expo/vector-icons" "^15.0.2"
     "@ungap/structured-clone" "^1.3.0"
-    babel-preset-expo "~55.0.22"
-    expo-asset "~55.0.17"
-    expo-constants "~55.0.16"
-    expo-file-system "~55.0.22"
+    babel-preset-expo "~55.0.24"
+    expo-asset "~55.0.18"
+    expo-constants "~55.0.17"
+    expo-file-system "~55.0.24"
     expo-font "~55.0.8"
     expo-keep-awake "~55.0.8"
-    expo-modules-autolinking "55.0.24"
+    expo-modules-autolinking "55.0.25"
     expo-modules-core "55.0.25"
     pretty-format "^29.7.0"
     react-refresh "^0.14.2"
@@ -5613,13 +5616,13 @@ jest-environment-node@^29.7.0:
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
-jest-expo@~55.0.18:
-  version "55.0.18"
-  resolved "https://registry.yarnpkg.com/jest-expo/-/jest-expo-55.0.18.tgz#a3d9b1f25c65a45433dc6bb267c92ef402a5ad54"
-  integrity sha512-kfa3iwTHSf5+ZOkxpWtjqZZ78AZvCSpYMkW/mSMNdffFAfEIqD2x1+WNf38U0vAhByaiGYP+m+Hgo4isOhYjkQ==
+jest-expo@~55.0.20:
+  version "55.0.20"
+  resolved "https://registry.yarnpkg.com/jest-expo/-/jest-expo-55.0.20.tgz#8100f755b6b174380024d9db7b15811f51120d1e"
+  integrity sha512-55NG6HFyFIViAo3eMWAidFTVPN8nTZU8b5Ed1YtNtYYA6aWmqa72fvHLP/phQdYaxIjFP2wdm1JO/+xEf5CdGQ==
   dependencies:
-    "@expo/config" "~55.0.17"
-    "@expo/json-file" "^10.0.14"
+    "@expo/config" "~55.0.19"
+    "@expo/json-file" "^10.0.15"
     "@jest/create-cache-key-function" "^29.2.1"
     "@jest/globals" "^29.2.1"
     babel-jest "^29.2.1"
@@ -7720,19 +7723,19 @@ react-native-worklets@0.7.4:
     convert-source-map "2.0.0"
     semver "7.7.3"
 
-react-native@0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.83.6.tgz#52933f34fdfc9d760d3da17f5ce1c97b7bd73f13"
-  integrity sha512-H513+8VzviNFXOdPnStRzX9S3/jiJGg++QZ1zd+ROyAvBEKqFqKUPHH0d82y3QyRPct5qKjdOa7J6vNehCvXYA==
+react-native@0.83.10:
+  version "0.83.10"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.83.10.tgz#3c10fe9c17c7baef383547c97082fa1f04a79971"
+  integrity sha512-4gbmtAyfC0F4jU2hl/l/HZbRIfRl0d5RdHNpJLf7sT/0zhYDEhiFcFk7ii2utl7O8BIHRUmGe/anfWP3DNPTZw==
   dependencies:
     "@jest/create-cache-key-function" "^29.7.0"
-    "@react-native/assets-registry" "0.83.6"
-    "@react-native/codegen" "0.83.6"
-    "@react-native/community-cli-plugin" "0.83.6"
-    "@react-native/gradle-plugin" "0.83.6"
-    "@react-native/js-polyfills" "0.83.6"
-    "@react-native/normalize-colors" "0.83.6"
-    "@react-native/virtualized-lists" "0.83.6"
+    "@react-native/assets-registry" "0.83.10"
+    "@react-native/codegen" "0.83.10"
+    "@react-native/community-cli-plugin" "0.83.10"
+    "@react-native/gradle-plugin" "0.83.10"
+    "@react-native/js-polyfills" "0.83.10"
+    "@react-native/normalize-colors" "0.83.10"
+    "@react-native/virtualized-lists" "0.83.10"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     ansi-regex "^5.0.0"
@@ -8746,9 +8749,9 @@ undici-types@~7.16.0:
   integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 undici@^6.22.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.26.0.tgz#333a35b7f519c48d2dc6aeb38e4e91d9274e0652"
-  integrity sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Prérequis au passage SDK 56 ([COM-4270](https://www.notion.so/compani/3b2f10fd4b03801799ead806ffbc8f04)) : partir d'une base saine permet d'attribuer sans ambiguïté les erreurs de la montée de SDK.

Ticket : [COM-4275](https://www.notion.so/compani/3baf10fd4b0380e1a33dcc252e5b61b8)

### Ce que fait cette PR

- **23 paquets alignés** sur les versions attendues par le SDK 55 : `expo` 55.0.26 → 55.0.28, `react-native` 0.83.6 → 0.83.10, les modules `expo-*` et `jest-expo`.
- **Doublon natif résolu** : `expo-image-loader` était installé en 55.0.0 et 55.0.1 (imbriqué dans `expo-image-manipulator`). Deux versions d'un même module natif peuvent casser un build.
- **`@sentry/react-native` ajouté à `expo.install.exclude`** : la v8 est volontaire (cf. bump v7 → v8 déjà livré) alors qu'Expo attend encore `~7.11.0` pour le SDK 55. Sans cette exclusion, `expo install --fix` rétrograde le paquet — ça s'est produit pendant la préparation de cette PR.

`expo-doctor` : **17/17** checks (le compte de checks de l'outil a évolué depuis ; cf. rapport de test).

### Changelogs vérifiés

Aucun breaking change — ce sont des versions de patch à l'intérieur du SDK 55. Vérification faite sur les changelogs des 8 modules les plus significatifs : aucune section « 🛠 Breaking changes » dans la plage bumpée.

Correctifs notables :
- **Sécurité** : traversée de répertoire dans `expo-file-system` (`createFile`/`createDirectory`/`rename`) ; `CropImageActivity` exportée dans `expo-image-picker` (Android).
- **RN 0.83.10** : crash iOS sur `removeClippedSubviews`, URL de `fetch()` correcte après redirection (Android), correctifs Yoga.
- **`expo-image-manipulator`** : orientation HEIC préservée. Seul changement visible côté utilisateur — une photo portrait pouvait être mal orientée.

### TESTS  :computer:

- J'ai testé sur iphone : 
  - [ ] simulateur
  - [ ] physique
- J'ai testé sur android :
  - [ ] simulateur
  - [ ] physique
- [ ] J'ai testé sur navigateur

> Pas de test sur appareil : cette PR ne touche que des versions de dépendances. Vérifications faites : `expo-doctor` 17/17, `yarn test` ✅, `npx tsc --noEmit` ✅ sans erreur.
> Le protocole de test manuel complet (appareil photo, galerie, cartes média, drag-and-drop) est prévu sur la PR du SDK 56.

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de déploiement](https://www.notion.so/compani/Distribution-mobile-MEP-d7238605d8c74cc59fa724ca5d94f253) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [Doc de déploiement](https://www.notion.so/compani/Distribution-mobile-MEP-d7238605d8c74cc59fa724ca5d94f253) qu'il faut fusionner l'api dans staging avant d'envoyer le build et déprécier les anciennes versions

_Si tu as lu cette description, pense à réagir avec un :eye:_

---

## 🧪 Rapport de test manuel — 20/08/2026

**Précision de méthode** : les trois PR de la pile (#805 → #806 → #807) sont empilées et destinées à être
mergées dans l'ordre. J'ai donc testé la branche `COM-4276`, qui **contient les trois cumulées**, plutôt que
chaque PR isolément. Ce rapport valide donc cette PR *par transitivité* : son code est exercé, mais aucun
test n'a été mené sur `COM-4275` seule. Le rapport détaillé complet est sur
[#807](https://github.com/CompaniTech/compani-formation/pull/807).

C'est un choix assumé : tester `COM-4275` isolément demanderait un build local dédié (~40 min) pour un état
intermédiaire qui ne sera jamais déployé tel quel.

### Ce que le test confirme pour cet assainissement

L'objectif de ce ticket était de préparer le terrain avant les montées de SDK. Les indicateurs qui le
valident, relevés sur l'état final :

| Contrôle | Résultat |
|---|---|
| `tsc --noEmit` | ✅ propre |
| `eslint ./src` | ✅ propre |
| `yarn test` (jest) | ✅ 1 suite, 1 test |
| Bundling Metro | ✅ **3 002 modules en 12,5 s**, aucune erreur de résolution |
| Démarrage app + parcours de 5 écrans | ✅ **0 erreur** au runtime |

L'absence d'erreur de résolution de module au bundling est le signe le plus direct que l'assainissement des
dépendances a fait son travail : c'est exactement là que des dépendances Expo mal alignées se manifestent.

### Point de suivi issu du test — depuis corrigé

`expo-doctor` signalait **13 paquets Expo en retard d'un ou deux patchs** (16/17), conséquence du lockfile
figé au 13/08. **C'est corrigé** dans [#807](https://github.com/CompaniTech/compani-formation/pull/807)
(commit `1ce9bb2b`), qui aligne la pile et fait passer le diagnostic à **17/17**. Rien à faire sur cette PR.

### Non couvert

- **Cette branche isolément** : non buildée ni exécutée seule (voir la précision de méthode ci-dessus).
- **Écrans post-connexion, Android, appareil physique, OTA, notifications** : voir la section « Non couvert »
  détaillée de #807.


