### PR TITLE
COM-4280: document .env.local override to disable sentry locally

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,39 @@
+# Exemple de fichier de surcharges locales.
+#
+# Copier en `.env.local` (non versionné) pour surcharger ponctuellement des variables
+# du `.env` sans le modifier. Expo charge `.env.local` en priorité sur `.env`, et seules
+# les variables déclarées ici sont remplacées : les autres gardent la valeur du `.env`.
+#
+#     cp .env.local.example .env.local
+#
+# ⚠️ Ne jamais mettre de secret ici : ce fichier est versionné, contrairement à `.env.local`.
+
+
+# ── Désactiver Sentry en local ────────────────────────────────────────────────
+#
+# Un DSN vide suffit : le SDK trace « No DSN provided, client will not send events »
+# et n'envoie plus rien, sans qu'il faille toucher au code (`Sentry.init` reste appelé,
+# les `Sentry.*` du code continuent de fonctionner sans effet).
+#
+# Pourquoi : `Sentry.init` tague les évènements avec le PROFILE (`src/App/index.tsx`),
+# donc un build local remonte dans le MÊME projet Sentry que la production, en
+# `environment: local`. Ça déclenche des alertes dans #crisp-chats et ça pollue le
+# triage — d'autant que `scripts/bugFollowUp.js` ne filtre pas par environnement et
+# créerait des fiches Notion pour ces évènements.
+#
+# À décommenter pendant les sessions de test sur simulateur ; à laisser commenté (ou
+# supprimer le `.env.local`) quand on veut justement vérifier la remontée d'erreurs.
+#
+# SENTRY_KEY=
+
+
+# ── Pointer l'app vers une API locale ─────────────────────────────────────────
+#
+# Par défaut `BASE_URL_LOCAL` vise `api.dev.compani.fr` (environnement partagé).
+# Pour travailler contre l'API de la machine, mettre l'IP du réseau local — pas
+# `localhost`, qui depuis le simulateur désigne le simulateur lui-même.
+#
+# Penser à aligner `FORMATION_MOBILE_VERSION` dans le `.env` de compani-api sur la
+# version de l'app, sinon l'écran bloquant « Nouvelle version disponible » s'affiche.
+#
+# BASE_URL_LOCAL=http://192.168.1.10:3000

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ env/*
 api-*
 .idea/*
 .env
+.env.local
+!.env.local.example
 
 # macOS
 .DS_Store


### PR DESCRIPTION
### TESTS  :computer:

- J'ai testé sur iphone : 
  - [x] simulateur
  - [ ] physique
- J'ai testé sur android :
  - [ ] simulateur
  - [ ] physique
- [ ] J'ai testé sur navigateur

---

### POINTS D'ATTENTION POUR CETTE PR  :warning:

- [ ] J'ai ajouté une variable d'environnement
  - [ ] Si oui, J'ai précisé sur le [Doc de déploiement](https://www.notion.so/compani/Distribution-mobile-MEP-d7238605d8c74cc59fa724ca5d94f253) ce qu'il fallait mettre à jour
- [ ] Mes changements entrainent une incompatibilité avec l'ancienne version de l'api
  - [ ] Si oui, j'ai noté dans le [Doc de déploiement](https://www.notion.so/compani/Distribution-mobile-MEP-d7238605d8c74cc59fa724ca5d94f253) qu'il faut fusionner l'api dans staging avant d'envoyer le build et déprécier les anciennes versions

_Si tu as lu cette description, pense à réagir avec un :eye:_

---

**Aucun code applicatif modifié.** Deux fichiers : un `.env.local.example` versionné qui documente comment
surcharger des variables en local, et `.gitignore` pour ignorer le `.env.local` sans perdre l'exemple.

### Le problème

`Sentry.init` (`src/App/index.tsx`) tague les évènements avec le `PROFILE`. Un build local remonte donc dans
le **même projet Sentry que la production**, en `environment: local`.

Constaté ce matin : une session de tests sur simulateur (montage de la pile SDK 57, bascules de branches avec
rechargement à chaud Metro) a produit **25 évènements `local`** sur 2 nouvelles issues —
`MOBILE-MA` (*Tried to register two views with the same name RNCViewPager*) et `MOBILE-M9` (*TypeError* dans
`CardTemplate`). Les deux ont déclenché des alertes dans `#crisp-chats` : **4 messages à trier pour des bugs
qui n'existent pas en production.**

Aggravant : `scripts/bugFollowUp.js` **ne filtre pas par environnement** (son seul filtre est temporel, 3
jours ; le paramètre `env` est un *slug de projet* Sentry, pas un environnement de déploiement). Lancé sur
une de ces issues, il aurait créé des fiches Notion pour des évènements de machine de dev.

<details>
<summary><b>Vérification : la pratique historique ne suit que la production</b></summary>

Sur la base « Suivi des bugs » (**6 815 fiches**, 264 issues), échantillon de 108 fiches dont l'évènement
Sentry est encore récupérable (au-delà, Sentry purge les détails) :

| Environnement | Fiches |
|---|---|
| `production` | **107** (99,1 %) |
| `development` | 1 |

Aucune fiche `staging` ni `local` en 3 ans. Ne plus émettre depuis le local est donc aligné avec l'usage
établi — ça ne change rien à ce qui est suivi.

</details>

### La solution

Le mécanisme existait déjà, il n'était juste pas documenté : `getSentryKey()` renvoie `''` quand
`SENTRY_KEY` est absent, et un **DSN vide désactive proprement l'envoi**. C'est explicite dans le SDK
(`@sentry/core/build/cjs/client.js:187`) :

```
No DSN provided, client will not send events.
```

`Sentry.init` reste appelé et tous les `Sentry.*` du code continuent de fonctionner sans effet — aucun risque
de casser un appel existant.

Il suffit donc d'un `.env.local` (non versionné) contenant `SENTRY_KEY=`. Expo le charge en priorité sur
`.env`, et **seules les variables déclarées sont remplacées**.

### Vérifié

```
$ npx expo config --type public --json
  SENTRY_KEY : ''          ← surchargé, Sentry désactivé
  PROFILE    : 'local'     ← inchangé, vient toujours du .env
  BASE_URL_LOCAL : 'https://api.dev.compani.fr'   ← inchangé
```

C'est le point qui compte : la surcharge est **ciblée**, elle ne perturbe pas le reste de la config.

| Contrôle | Résultat |
|---|---|
| `SENTRY_KEY` surchargé à `''` | ✅ |
| `PROFILE` et `BASE_URL_LOCAL` intacts | ✅ |
| `git check-ignore .env.local` | ✅ ignoré |
| `.env.local.example` versionné | ✅ (via `!.env.local.example`) |
| `tsc --noEmit` + `eslint` | ✅ propres |
| Config Expo valide (nom, version) | ✅ |

### Un choix à valider

J'ai **écarté volontairement** le garde-fou dans le code (`dsn: PROFILE === LOCAL ? '' : getSentryKey()`),
parce qu'il retirerait la possibilité de tester la remontée Sentry en local — ce qui sert précisément sur un
chantier comme le bump Sentry v8.

La contrepartie est réelle et je l'assume : **la protection ne s'applique qu'aux machines où le `.env.local`
existe.** Si le problème se reproduit chez quelqu'un d'autre, le garde-fou dans le code devient le bon
choix — dites-le et je le fais.

### Portée : on tarit la source, on ne touche pas au script

Le choix retenu est de traiter **uniquement la cause** — ne plus émettre d'évènements depuis le local — et de
**ne rien ajouter à `bugFollowUp.js`**, pour garder le script simple.

À savoir tout de même pour la review : ce script ne filtre que sur les 3 derniers jours, et son paramètre
`env` (`mobile` / `api` / `mobile-erp`) est un *slug de projet* Sentry, pas un environnement de déploiement.
Il ne distingue donc pas prod / staging / local — d'où l'intérêt de ne pas polluer Sentry en amont.

### Non couvert

- **Android** : non testé, mais le mécanisme est côté configuration Expo, indépendant de la plateforme.
- Le fichier d'exemple documente aussi le pointage vers une API locale (`BASE_URL_LOCAL`), utilisé aujourd'hui
  pour tester les écrans post-connexion sur #808. Pensez à aligner `FORMATION_MOBILE_VERSION` côté
  `compani-api`, sinon l'écran bloquant « Nouvelle version disponible » s'affiche.



---

## 🩺 `react-doctor` confirme ce correctif — 20/08/2026

Passe d'analyse statique avec [`react-doctor@0.9.12`](https://github.com/millionco/react-doctor) (l'outil du
ticket COM-4250). Il signalait sur `dev` un diagnostic **de catégorie Security** :

```
[Security] expo-env-local-not-gitignored
Local environment file (.env.local) is not ignored by Git — committing `.env*.local`
risks leaking secrets and overriding committed defaults for everyone who clones the project
```

Sur cette branche, **il a disparu** :

| Branche | Score | Warnings | Diagnostics Security |
|---|---|---|---|
| `dev` | 50 | 214 | 2 (`expo-env-local-not-gitignored`, `iframe-missing-sandbox`) |
| `COM-4280-env-local` | 50 | **213** | **1** (`iframe-missing-sandbox` seul) |

L'ajout de `.env.local` au `.gitignore` — que je faisais surtout par prudence — est donc validé
indépendamment comme une correction de sécurité. Le risque était réel : sans cette ligne, un `.env.local`
contenant un `SENTRY_AUTH_TOKEN` ou une URL d'API pouvait partir dans un commit.


